### PR TITLE
refactor: centralize environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,13 +19,69 @@ ROLE_C=
 # 退出ログチャンネル
 LEAVE_LOG_CHANNEL_ID=
 
+# DM転送先ユーザー
+DM_FORWARD_USER_ID=
 
 # ==========================================
 # ✅ Reaction Role（ゲームカテゴリー）
 # ==========================================
-
+REACTION_ROLE_MESSAGE_IDS=
+RR_GAME_VALO=
+RR_GAME_EFT=
+RR_GAME_SF6=
+RR_GAME_MONSTER_HUNTER=
+RR_GAME_OW2=
+RR_GAME_APEX=
 
 # ==========================================
 # ✅ Reaction Role（VALORANT ランク）
 # ==========================================
+RR_V_IRON=
+RR_V_BRONZE=
+RR_V_SILVER=
+RR_V_GOLD=
+RR_V_PLATINUM=
+RR_V_DIAMOND=
+RR_V_ASCENDANT=
+RR_V_IMMORTAL=
+RR_V_RADIANT=
 
+# ==========================================
+# ✅ VALORANT診断・募集
+# ==========================================
+ROLE_ENJOY_ID=
+ROLE_GACHI_ID=
+VALO_ROLE_LOG_CHANNEL_ID=
+VALO_CHECK_VIEW_TIMEOUT_SEC=1800
+VALO_CHECK_DATA_PATH=data/valo_check_completed.json
+VALO_CHECK_QUESTIONS_PATH=data/valo_questions.json
+VALO_CHECK_INTRO_PATH=data/valo_intro.json
+VALO_CHECK_THRESH_ENJOY_ONLY=6
+VALO_CHECK_THRESH_GACHI_ONLY=12
+VALO_CHECK_LABEL_ENJOY=ENJOYのみ
+VALO_CHECK_LABEL_GACHI=GACHIのみ
+VALO_CHECK_LABEL_BOTH=GACHI+ENJOY
+
+VALO_RECRUIT_CHANNEL_ID=
+VALO_ROLE_GACHI_ID=
+VALO_ROLE_ENJOY_ID=
+VALO_RECRUIT_COOLDOWN_SECONDS=300
+
+# ==========================================
+# ✅ イベントとruntime JSON
+# ==========================================
+XMAS_GACHA_CSV=/home/akitig/Desktop/Bot/Toureikai/Wankorobot/data/2025_xmas_gacha.csv
+XMAS_GACHA_STATE=/home/akitig/Desktop/Bot/Toureikai/Wankorobot/data/xmas_gacha_state.json
+XMAS_GACHA_CHANNEL_ID=
+XMAS_GACHA_CUTOFF=2025-12-26T07:00:00+09:00
+
+JOYA_DATA_PATH=./data/joya_state.json
+JOYA_MIN_SEC=60
+JOYA_MAX_SEC=300
+JOYA_WINNER_ROLE_ID=
+JOYA_CHANNEL_ID=
+
+OMIKUJI_POINTS_PATH=data/2026_omikujii_points.json
+OMIKUJI_REST_VC_ID=
+OMIKUJI_RESETTER_USER_ID=
+OMIKUJI_PANEL_CHANNEL_ID=

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ python3 -m venv .venv
 
 `.env.example` をコピーし、値を設定してください。systemdの
 `EnvironmentFile`で読み込めるよう、環境変数名にはASCII英大文字・数字・
-アンダースコアのみを使用します。
+アンダースコアのみを使用します。全設定、型、デフォルト値、runtime pathは
+[`docs/architecture/configuration.md`](docs/architecture/configuration.md)を
+参照してください。
 
 ```env
 DISCORD_TOKEN=xxxxxxxxxxxxxxxx

--- a/cogs/2025_xmas_gacha.py
+++ b/cogs/2025_xmas_gacha.py
@@ -1,6 +1,5 @@
 import asyncio
 import csv
-import os
 import random
 from dataclasses import dataclass
 from datetime import datetime
@@ -10,6 +9,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from config import get_config
 from storage.json_store import load_json_or_default, save_json_atomic
 
 try:
@@ -20,34 +20,11 @@ except ImportError:
 STATE_NONE = "__NONE__"
 
 
-def _get_env_str(key: str, default: str) -> str:
-    v = os.getenv(key)
-    if v is None or v.strip() == "":
-        return default
-    return v.strip()
-
-
-def _get_env_int(key: str, default: int) -> int:
-    v = os.getenv(key)
-    if v is None:
-        return default
-    try:
-        return int(v.strip())
-    except ValueError:
-        return default
-
-
-DATA_DIR = "/home/akitig/Desktop/Bot/Toureikai/Wankorobot/data"
-CSV_PATH = _get_env_str(
-    "XMAS_GACHA_CSV",
-    os.path.join(DATA_DIR, "2025_xmas_gacha.csv"),
-)
-STATE_PATH = _get_env_str(
-    "XMAS_GACHA_STATE",
-    os.path.join(DATA_DIR, "xmas_gacha_state.json"),
-)
-CHANNEL_ID = _get_env_int("XMAS_GACHA_CHANNEL_ID", 0)
-CUTOFF_RAW = _get_env_str("XMAS_GACHA_CUTOFF", "2025-12-26T07:00:00+09:00")
+config = get_config()
+CSV_PATH = config.xmas_gacha_csv_path
+STATE_PATH = config.xmas_gacha_state_path
+CHANNEL_ID = config.xmas_gacha_channel_id
+CUTOFF_RAW = config.xmas_gacha_cutoff
 
 CLOSED_MESSAGES_MAIN = [
     "まだクリスマスの気分かい？\n街はもう、いつもの顔に戻ってる。",
@@ -144,7 +121,7 @@ def _panel_embed() -> discord.Embed:
 
 
 def _read_csv_rewards() -> List[t_reward]:
-    if not os.path.exists(CSV_PATH):
+    if not CSV_PATH.exists():
         return []
     rewards: List[t_reward] = []
     with open(CSV_PATH, "r", encoding="utf-8", newline="") as f:

--- a/cogs/2026_joya_gacha.py
+++ b/cogs/2026_joya_gacha.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import random
 import time
 from dataclasses import dataclass
@@ -9,17 +8,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from config import get_config
 from storage.json_store import load_json_or_default, save_json_atomic
-
-
-def _get_int_env(key: str, default: int) -> int:
-    v = os.getenv(key)
-    if not v:
-        return default
-    try:
-        return int(v)
-    except ValueError:
-        return default
 
 
 def _now_ts() -> int:
@@ -123,13 +113,13 @@ class JoyaView(discord.ui.View):
 class JoyaGacha(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self._min_env = _get_int_env("JOYA_MIN_SEC", 60)
-        self._max_env = _get_int_env("JOYA_MAX_SEC", 300)
-        self._role_id = _get_int_env("JOYA_WINNER_ROLE_ID", 0)
-        self._channel_id = _get_int_env("JOYA_CHANNEL_ID", 0)
+        config = get_config()
+        self._min_env = config.joya_min_sec
+        self._max_env = config.joya_max_sec
+        self._role_id = config.joya_winner_role_id
+        self._channel_id = config.joya_channel_id
         self._block_role_id = 1451758143636901960
-        path = os.getenv("JOYA_DATA_PATH", "./data/joya_state.json")
-        self._store = _JoyaStore(path)
+        self._store = _JoyaStore(config.joya_data_path)
         self._locks: Dict[int, asyncio.Lock] = {}
 
     async def cog_load(self) -> None:

--- a/cogs/2026_omikuji_gacha.py
+++ b/cogs/2026_omikuji_gacha.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import random
 from dataclasses import dataclass
 from typing import Dict, Optional
@@ -8,24 +7,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from config import get_config
 from storage.json_store import load_json_or_default, save_json_atomic
-
-
-def _get_env_str(key: str, default: str) -> str:
-    v = os.getenv(key)
-    if v is None or v.strip() == "":
-        return default
-    return v.strip()
-
-
-def _get_env_int(key: str, default: int) -> int:
-    v = os.getenv(key)
-    if v is None or v.strip() == "":
-        return default
-    try:
-        return int(v.strip())
-    except ValueError:
-        return default
 
 
 @dataclass
@@ -37,12 +20,12 @@ class t_omikuji_env:
 
 
 def _load_env() -> t_omikuji_env:
-    default_path = os.path.join("data", "2026_omikujii_points.json")
+    config = get_config()
     return t_omikuji_env(
-        rest_vc_id=_get_env_int("OMIKUJI_REST_VC_ID", 0),
-        resetter_user_id=_get_env_int("OMIKUJI_RESETTER_USER_ID", 0),
-        panel_channel_id=_get_env_int("OMIKUJI_PANEL_CHANNEL_ID", 0),
-        points_path=_get_env_str("OMIKUJI_POINTS_PATH", default_path),
+        rest_vc_id=config.omikuji_rest_vc_id,
+        resetter_user_id=config.omikuji_resetter_user_id,
+        panel_channel_id=config.omikuji_panel_channel_id,
+        points_path=str(config.omikuji_points_path),
     )
 
 

--- a/cogs/dm_forward.py
+++ b/cogs/dm_forward.py
@@ -1,22 +1,13 @@
-import os
 import discord
 from discord.ext import commands
 
-
-def _get_opt_int_env(key: str):
-    v = os.getenv(key)
-    if not v:
-        return None
-    try:
-        return int(v)
-    except ValueError:
-        return None
+from config import get_config
 
 
 class DmForwardCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        self.forward_user_id = _get_opt_int_env("DM_FORWARD_USER_ID")
+        self.forward_user_id = get_config().dm_forward_user_id
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):

--- a/cogs/leave_log.py
+++ b/cogs/leave_log.py
@@ -1,12 +1,17 @@
 import discord
 from discord.ext import commands
 import asyncio
-import os
+
+from config import get_config
 
 class LeaveLog(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.LEAVE_LOG_CHANNEL_ID = int(os.getenv("LEAVE_LOG_CHANNEL_ID"))
+        config = get_config()
+        self.LEAVE_LOG_CHANNEL_ID = config.require_id(
+            config.leave_log_channel_id,
+            "LEAVE_LOG_CHANNEL_ID",
+        )
         self.recent_bans = {}
         self.recent_kicks = {}
 

--- a/cogs/reaction_roles.py
+++ b/cogs/reaction_roles.py
@@ -1,9 +1,9 @@
-import os
 import re
 import discord
 from discord.ext import commands
 from discord import app_commands
 
+from config import get_config
 
 ENV_KEY_PATTERN = re.compile(r"^[A-Z_][A-Z0-9_]*$")
 
@@ -21,13 +21,12 @@ GAME_REACTION_ROLES = {
 class ReactionRoles(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        self.GUILD_ID = int(os.getenv("GUILD_ID"))
+        config = get_config()
+        self.GUILD_ID = config.guild_id
 
         # カンマ区切りで複数のメッセージに対応
-        raw_ids = os.getenv("REACTION_ROLE_MESSAGE_IDS", "")
-        self.REACTION_ROLE_MESSAGE_IDS = {
-            int(x) for x in raw_ids.split(",") if x.strip().isdigit()
-        }
+        self.REACTION_ROLE_MESSAGE_IDS = set(config.reaction_role_message_ids)
+        self._reaction_role_values = config.reaction_role_values
 
         self.reaction_role_map = {}
         self.load_reaction_roles()
@@ -37,7 +36,7 @@ class ReactionRoles(commands.Cog):
     # ======================================================
     def load_reaction_roles(self):
         self.reaction_role_map.clear()
-        for key, value in os.environ.items():
+        for key, value in self._reaction_role_values.items():
             if key.startswith("RR_"):
                 try:
                     emoji_id, role_id = value.split(":")

--- a/cogs/valocheck.py
+++ b/cogs/valocheck.py
@@ -1,5 +1,4 @@
 import json
-import os
 import random
 from datetime import datetime, timezone
 
@@ -7,45 +6,8 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from config import get_config
 from storage.json_store import load_json, load_json_or_default, save_json_atomic
-
-
-def _get_int_env(key: str) -> int:
-    v = os.getenv(key)
-    if not v:
-        raise RuntimeError(f"Missing env: {key}")
-    return int(v)
-
-
-def _get_opt_int_env(key: str, default: int) -> int:
-    v = os.getenv(key)
-    if not v:
-        return default
-    try:
-        return int(v)
-    except ValueError:
-        return default
-
-
-def _get_str_env(key: str, default: str) -> str:
-    v = os.getenv(key)
-    if not v:
-        return default
-    return v
-
-
-def _get_opt_id_env(key: str):
-    v = os.getenv(key)
-    if not v:
-        return None
-    try:
-        return int(v)
-    except ValueError:
-        return None
-
-
-def _get_opt_channel_id_env(key: str):
-    return _get_opt_id_env(key)
 
 
 def _utc_now() -> str:
@@ -207,22 +169,25 @@ class StartView(discord.ui.View):
 class ValoCheckCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
+        config = get_config()
 
-        self.guild_id = _get_int_env("GUILD_ID")
-        self.role_enjoy_id = _get_int_env("ROLE_ENJOY_ID")
-        self.role_gachi_id = _get_int_env("ROLE_GACHI_ID")
-
-        self.log_channel_id = _get_opt_channel_id_env("VALO_ROLE_LOG_CHANNEL_ID")
-        self.admin_dm_user_id = _get_opt_id_env("DM_FORWARD_USER_ID")
-        self.view_timeout_sec = _get_opt_int_env("VALO_CHECK_VIEW_TIMEOUT_SEC", 1800)
-
-        self.data_path = _get_str_env(
-            "VALO_CHECK_DATA_PATH", "data/valo_check_completed.json"
+        self.guild_id = config.guild_id
+        self.role_enjoy_id = config.require_id(
+            config.valo_role_enjoy_id,
+            "ROLE_ENJOY_ID",
         )
-        self.questions_path = _get_str_env(
-            "VALO_CHECK_QUESTIONS_PATH", "data/valo_questions.json"
+        self.role_gachi_id = config.require_id(
+            config.valo_role_gachi_id,
+            "ROLE_GACHI_ID",
         )
-        self.intro_path = _get_str_env("VALO_CHECK_INTRO_PATH", "data/valo_intro.json")
+
+        self.log_channel_id = config.valo_role_log_channel_id
+        self.admin_dm_user_id = config.dm_forward_user_id
+        self.view_timeout_sec = config.valo_check_view_timeout_sec
+
+        self.data_path = config.valo_check_data_path
+        self.questions_path = config.valo_check_questions_path
+        self.intro_path = config.valo_check_intro_path
 
         intro = _load_intro(self.intro_path)
         if intro is None:
@@ -231,12 +196,12 @@ class ValoCheckCog(commands.Cog):
         else:
             self.intro_title, self.intro_text = intro
 
-        self.thresh_enjoy_only = _get_opt_int_env("VALO_CHECK_THRESH_ENJOY_ONLY", 6)
-        self.thresh_gachi_only = _get_opt_int_env("VALO_CHECK_THRESH_GACHI_ONLY", 12)
+        self.thresh_enjoy_only = config.valo_check_thresh_enjoy_only
+        self.thresh_gachi_only = config.valo_check_thresh_gachi_only
 
-        self.label_enjoy = _get_str_env("VALO_CHECK_LABEL_ENJOY", "ENJOYのみ")
-        self.label_gachi = _get_str_env("VALO_CHECK_LABEL_GACHI", "GACHIのみ")
-        self.label_both = _get_str_env("VALO_CHECK_LABEL_BOTH", "GACHI+ENJOY")
+        self.label_enjoy = config.valo_check_label_enjoy
+        self.label_gachi = config.valo_check_label_gachi
+        self.label_both = config.valo_check_label_both
 
         self.questions = []
         self.max_score = 0

--- a/cogs/valomap.py
+++ b/cogs/valomap.py
@@ -1,4 +1,3 @@
-import os
 import random
 
 import aiohttp
@@ -6,15 +5,16 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
+from config import get_config
 from storage.json_store import load_json_or_default, save_json_atomic
 
 VALO_API_URL = "https://valorant-api.com/v1/maps"
-BAN_FILE = "valomap_bans.json"
 
 
 class ValorantMap(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
+        self.config = get_config()
         self.cached_maps = []
         self.banned_maps = set()
         self.load_bans()
@@ -23,13 +23,16 @@ class ValorantMap(commands.Cog):
     # 🔹 BANファイルの読み書き
     # -------------------------------
     def load_bans(self):
-        data = load_json_or_default(BAN_FILE, {"bans": []})
+        data = load_json_or_default(self.config.valomap_bans_path, {"bans": []})
         self.banned_maps = set(data.get("bans", []))
         print(f"🚫 Loaded banned maps: {self.banned_maps}")
 
     def save_bans(self):
         try:
-            save_json_atomic(BAN_FILE, {"bans": list(self.banned_maps)})
+            save_json_atomic(
+                self.config.valomap_bans_path,
+                {"bans": list(self.banned_maps)},
+            )
             print(f"💾 Saved banned maps: {self.banned_maps}")
         except (OSError, TypeError, ValueError):
             print("⚠️ Failed to save ban file.")
@@ -212,7 +215,7 @@ class ValorantMap(commands.Cog):
     # -------------------------------
     @commands.Cog.listener()
     async def on_ready(self):
-        guild = discord.Object(id=int(os.getenv("GUILD_ID")))
+        guild = discord.Object(id=self.config.guild_id)
         try:
             self.bot.tree.add_command(self.valomap_all, guild=guild)
             self.bot.tree.add_command(self.valomap_pool, guild=guild)

--- a/cogs/valorecruit.py
+++ b/cogs/valorecruit.py
@@ -1,25 +1,9 @@
-import os
 import time
 import discord
 from discord import app_commands
 from discord.ext import commands
 
-
-def _get_int_env(key: str) -> int:
-    v = os.getenv(key)
-    if not v:
-        raise RuntimeError(f"Missing env: {key}")
-    return int(v)
-
-
-def _get_opt_int_env(key: str, default: int) -> int:
-    v = os.getenv(key)
-    if not v:
-        return default
-    try:
-        return int(v)
-    except ValueError:
-        return default
+from config import get_config
 
 
 def _has_forbidden_mentions(text: str) -> bool:
@@ -250,18 +234,28 @@ class ValoRecruitView(discord.ui.View):
 class ValoRecruitCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
-        channel_id = _get_int_env("VALO_RECRUIT_CHANNEL_ID")
-        gachi_id = _get_int_env("VALO_ROLE_GACHI_ID")
-        enjoy_id = _get_int_env("VALO_ROLE_ENJOY_ID")
-        cooldown = _get_opt_int_env("VALO_RECRUIT_COOLDOWN_SECONDS", 300)
+        config = get_config()
+        channel_id = config.require_id(
+            config.valo_recruit_channel_id,
+            "VALO_RECRUIT_CHANNEL_ID",
+        )
+        gachi_id = config.require_id(
+            config.valo_recruit_gachi_role_id,
+            "VALO_ROLE_GACHI_ID",
+        )
+        enjoy_id = config.require_id(
+            config.valo_recruit_enjoy_role_id,
+            "VALO_ROLE_ENJOY_ID",
+        )
+        cooldown = config.valo_recruit_cooldown_seconds
+        self.channel_id = channel_id
         self.view = ValoRecruitView(channel_id, gachi_id, enjoy_id, cooldown)
         bot.add_view(self.view)
 
     @app_commands.command(name="valo_panel", description="VALO募集パネルを設置します")
     @app_commands.checks.has_permissions(manage_guild=True)
     async def valo_panel(self, interaction: discord.Interaction) -> None:
-        channel_id = _get_int_env("VALO_RECRUIT_CHANNEL_ID")
-        channel = interaction.client.get_channel(channel_id)
+        channel = interaction.client.get_channel(self.channel_id)
         if not isinstance(channel, discord.TextChannel):
             await interaction.response.send_message(
                 "募集チャンネルが見つからないよ。",

--- a/cogs/welcome.py
+++ b/cogs/welcome.py
@@ -1,10 +1,10 @@
-import os
 import random
 import discord
 from discord.ext import commands
 from discord.ui import View, Button
 from discord import app_commands
 
+from config import get_config
 
 class Welcome(commands.Cog):
     def __init__(self, bot):
@@ -13,18 +13,20 @@ class Welcome(commands.Cog):
         self.processing_users = set()
 
         # --- 環境変数設定 ---
-        self.GUILD_ID = int(os.getenv("GUILD_ID"))
-        self.ADMIN_ID = int(os.getenv("ADMIN_ID"))
-        self.ROLE_A = int(os.getenv("ROLE_A"))
-        self.ROLE_B = int(os.getenv("ROLE_B"))
-        self.ROLE_C = int(os.getenv("ROLE_C"))
-        self.LEAVE_LOG_CHANNEL_ID = int(os.getenv("LEAVE_LOG_CHANNEL_ID"))
+        config = get_config()
+        self.GUILD_ID = config.guild_id
+        self.ADMIN_ID = config.require_id(config.admin_id, "ADMIN_ID")
+        self.ROLE_A = config.require_id(config.welcome_role_a, "ROLE_A")
+        self.ROLE_B = config.require_id(config.welcome_role_b, "ROLE_B")
+        self.ROLE_C = config.require_id(config.welcome_role_c, "ROLE_C")
+        self.LEAVE_LOG_CHANNEL_ID = config.require_id(
+            config.leave_log_channel_id,
+            "LEAVE_LOG_CHANNEL_ID",
+        )
         self.WELCOME_CATEGORY_NAME = "welcome"
         self.LOG_CATEGORY_NAME = "log"
 
-        self.MANAGER_ROLE_IDS = {
-            int(r) for r in os.getenv("MANAGER_ROLE_IDS", "").split(",") if r.strip().isdigit()
-        }
+        self.MANAGER_ROLE_IDS = set(config.manager_role_ids)
 
     # ------------------------------------------------------
     # ✅ 管理者判定

--- a/config.py
+++ b/config.py
@@ -1,0 +1,240 @@
+"""Typed application configuration loaded once from the process environment."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from types import MappingProxyType
+
+from dotenv import load_dotenv
+
+PRODUCTION_DATA_DIR = Path("/home/akitig/Desktop/Bot/Toureikai/Wankorobot/data")
+
+
+def _optional_int(name: str) -> int | None:
+    value = os.getenv(name)
+    if not value:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _int_with_default(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if not value:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _string_with_default(name: str, default: str, *, strip: bool = False) -> str:
+    value = os.getenv(name)
+    if value is None or (not strip and not value) or (strip and not value.strip()):
+        return default
+    return value.strip() if strip else value
+
+
+def _string_if_missing(name: str, default: str) -> str:
+    value = os.getenv(name)
+    return default if value is None else value
+
+
+def _required_int(name: str) -> int:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing environment variable: {name}")
+    return int(value)
+
+
+def _id_set(name: str) -> frozenset[int]:
+    value = os.getenv(name, "")
+    return frozenset(int(item) for item in value.split(",") if item.strip().isdigit())
+
+
+def _reaction_role_values() -> Mapping[str, str]:
+    values = {
+        key: value
+        for key, value in os.environ.items()
+        if key.startswith("RR_")
+    }
+    return MappingProxyType(values)
+
+
+@dataclass(frozen=True)
+class Config:
+    discord_token: str | None = field(repr=False)
+    application_id: int
+    guild_id: int
+
+    admin_id: int | None
+    manager_role_ids: frozenset[int]
+    welcome_role_a: int | None
+    welcome_role_b: int | None
+    welcome_role_c: int | None
+    leave_log_channel_id: int | None
+    dm_forward_user_id: int | None
+
+    reaction_role_message_ids: frozenset[int]
+    reaction_role_values: Mapping[str, str] = field(repr=False)
+
+    xmas_gacha_csv_path: Path
+    xmas_gacha_state_path: Path
+    xmas_gacha_channel_id: int
+    xmas_gacha_cutoff: str
+
+    joya_data_path: Path
+    joya_min_sec: int
+    joya_max_sec: int
+    joya_winner_role_id: int
+    joya_channel_id: int
+
+    omikuji_points_path: Path
+    omikuji_rest_vc_id: int
+    omikuji_resetter_user_id: int
+    omikuji_panel_channel_id: int
+
+    valomap_bans_path: Path
+    valo_check_data_path: Path
+    valo_check_questions_path: Path
+    valo_check_intro_path: Path
+    valo_role_enjoy_id: int | None
+    valo_role_gachi_id: int | None
+    valo_role_log_channel_id: int | None
+    valo_check_view_timeout_sec: int
+    valo_check_thresh_enjoy_only: int
+    valo_check_thresh_gachi_only: int
+    valo_check_label_enjoy: str
+    valo_check_label_gachi: str
+    valo_check_label_both: str
+
+    valo_recruit_channel_id: int | None
+    valo_recruit_gachi_role_id: int | None
+    valo_recruit_enjoy_role_id: int | None
+    valo_recruit_cooldown_seconds: int
+
+    def require_id(self, value: int | None, environment_name: str) -> int:
+        """Return a required Cog setting or fail when that Cog is constructed."""
+
+        if value is None:
+            raise RuntimeError(f"Missing environment variable: {environment_name}")
+        return value
+
+
+def _load_config() -> Config:
+    load_dotenv()
+    return Config(
+        discord_token=os.getenv("DISCORD_TOKEN"),
+        application_id=_required_int("APPLICATION_ID"),
+        guild_id=_required_int("GUILD_ID"),
+        admin_id=_optional_int("ADMIN_ID"),
+        manager_role_ids=_id_set("MANAGER_ROLE_IDS"),
+        welcome_role_a=_optional_int("ROLE_A"),
+        welcome_role_b=_optional_int("ROLE_B"),
+        welcome_role_c=_optional_int("ROLE_C"),
+        leave_log_channel_id=_optional_int("LEAVE_LOG_CHANNEL_ID"),
+        dm_forward_user_id=_optional_int("DM_FORWARD_USER_ID"),
+        reaction_role_message_ids=_id_set("REACTION_ROLE_MESSAGE_IDS"),
+        reaction_role_values=_reaction_role_values(),
+        xmas_gacha_csv_path=Path(
+            _string_with_default(
+                "XMAS_GACHA_CSV",
+                str(PRODUCTION_DATA_DIR / "2025_xmas_gacha.csv"),
+                strip=True,
+            )
+        ),
+        xmas_gacha_state_path=Path(
+            _string_with_default(
+                "XMAS_GACHA_STATE",
+                str(PRODUCTION_DATA_DIR / "xmas_gacha_state.json"),
+                strip=True,
+            )
+        ),
+        xmas_gacha_channel_id=_int_with_default("XMAS_GACHA_CHANNEL_ID", 0),
+        xmas_gacha_cutoff=_string_with_default(
+            "XMAS_GACHA_CUTOFF",
+            "2025-12-26T07:00:00+09:00",
+            strip=True,
+        ),
+        joya_data_path=Path(_string_if_missing("JOYA_DATA_PATH", "./data/joya_state.json")),
+        joya_min_sec=_int_with_default("JOYA_MIN_SEC", 60),
+        joya_max_sec=_int_with_default("JOYA_MAX_SEC", 300),
+        joya_winner_role_id=_int_with_default("JOYA_WINNER_ROLE_ID", 0),
+        joya_channel_id=_int_with_default("JOYA_CHANNEL_ID", 0),
+        omikuji_points_path=Path(
+            _string_with_default(
+                "OMIKUJI_POINTS_PATH",
+                "data/2026_omikujii_points.json",
+                strip=True,
+            )
+        ),
+        omikuji_rest_vc_id=_int_with_default("OMIKUJI_REST_VC_ID", 0),
+        omikuji_resetter_user_id=_int_with_default("OMIKUJI_RESETTER_USER_ID", 0),
+        omikuji_panel_channel_id=_int_with_default("OMIKUJI_PANEL_CHANNEL_ID", 0),
+        valomap_bans_path=Path("valomap_bans.json"),
+        valo_check_data_path=Path(
+            _string_with_default(
+                "VALO_CHECK_DATA_PATH",
+                "data/valo_check_completed.json",
+            )
+        ),
+        valo_check_questions_path=Path(
+            _string_with_default(
+                "VALO_CHECK_QUESTIONS_PATH",
+                "data/valo_questions.json",
+            )
+        ),
+        valo_check_intro_path=Path(
+            _string_with_default(
+                "VALO_CHECK_INTRO_PATH",
+                "data/valo_intro.json",
+            )
+        ),
+        valo_role_enjoy_id=_optional_int("ROLE_ENJOY_ID"),
+        valo_role_gachi_id=_optional_int("ROLE_GACHI_ID"),
+        valo_role_log_channel_id=_optional_int("VALO_ROLE_LOG_CHANNEL_ID"),
+        valo_check_view_timeout_sec=_int_with_default(
+            "VALO_CHECK_VIEW_TIMEOUT_SEC",
+            1800,
+        ),
+        valo_check_thresh_enjoy_only=_int_with_default(
+            "VALO_CHECK_THRESH_ENJOY_ONLY",
+            6,
+        ),
+        valo_check_thresh_gachi_only=_int_with_default(
+            "VALO_CHECK_THRESH_GACHI_ONLY",
+            12,
+        ),
+        valo_check_label_enjoy=_string_with_default(
+            "VALO_CHECK_LABEL_ENJOY",
+            "ENJOYのみ",
+        ),
+        valo_check_label_gachi=_string_with_default(
+            "VALO_CHECK_LABEL_GACHI",
+            "GACHIのみ",
+        ),
+        valo_check_label_both=_string_with_default(
+            "VALO_CHECK_LABEL_BOTH",
+            "GACHI+ENJOY",
+        ),
+        valo_recruit_channel_id=_optional_int("VALO_RECRUIT_CHANNEL_ID"),
+        valo_recruit_gachi_role_id=_optional_int("VALO_ROLE_GACHI_ID"),
+        valo_recruit_enjoy_role_id=_optional_int("VALO_ROLE_ENJOY_ID"),
+        valo_recruit_cooldown_seconds=_int_with_default(
+            "VALO_RECRUIT_COOLDOWN_SECONDS",
+            300,
+        ),
+    )
+
+
+@lru_cache(maxsize=1)
+def get_config() -> Config:
+    """Return the process-wide immutable Config instance."""
+
+    return _load_config()

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -1,0 +1,49 @@
+# Configuration boundary
+
+## Loading and lifetime
+
+`config.py` is the only active application module that reads environment
+variables or calls `load_dotenv()`. `get_config()` creates one immutable,
+process-wide `Config` instance and returns that cached instance to `main.py` and
+all Cogs. The Discord token is excluded from the Config representation.
+
+Existing environment names and defaults remain unchanged. Application and
+Guild IDs are required when Config is first loaded. Settings required by only
+one Cog remain optional in Config and are validated when that Cog is
+constructed, so a missing Cog-specific setting does not prevent unrelated Cogs
+from being attempted.
+
+## Environment variables
+
+| Area | Environment variables |
+|---|---|
+| Discord process | `DISCORD_TOKEN`, `APPLICATION_ID`, `GUILD_ID` |
+| Welcome and moderation | `ADMIN_ID`, `MANAGER_ROLE_IDS`, `ROLE_A`, `ROLE_B`, `ROLE_C`, `LEAVE_LOG_CHANNEL_ID`, `DM_FORWARD_USER_ID` |
+| Reaction Roles | `REACTION_ROLE_MESSAGE_IDS`, every `RR_*` mapping |
+| VALORANT check | `ROLE_ENJOY_ID`, `ROLE_GACHI_ID`, `VALO_ROLE_LOG_CHANNEL_ID`, `VALO_CHECK_VIEW_TIMEOUT_SEC`, `VALO_CHECK_DATA_PATH`, `VALO_CHECK_QUESTIONS_PATH`, `VALO_CHECK_INTRO_PATH`, `VALO_CHECK_THRESH_ENJOY_ONLY`, `VALO_CHECK_THRESH_GACHI_ONLY`, `VALO_CHECK_LABEL_ENJOY`, `VALO_CHECK_LABEL_GACHI`, `VALO_CHECK_LABEL_BOTH` |
+| VALORANT recruit | `VALO_RECRUIT_CHANNEL_ID`, `VALO_ROLE_GACHI_ID`, `VALO_ROLE_ENJOY_ID`, `VALO_RECRUIT_COOLDOWN_SECONDS` |
+| Christmas event | `XMAS_GACHA_CSV`, `XMAS_GACHA_STATE`, `XMAS_GACHA_CHANNEL_ID`, `XMAS_GACHA_CUTOFF` |
+| New Year bell event | `JOYA_DATA_PATH`, `JOYA_MIN_SEC`, `JOYA_MAX_SEC`, `JOYA_WINNER_ROLE_ID`, `JOYA_CHANNEL_ID` |
+| Omikuji event | `OMIKUJI_POINTS_PATH`, `OMIKUJI_REST_VC_ID`, `OMIKUJI_RESETTER_USER_ID`, `OMIKUJI_PANEL_CHANNEL_ID` |
+
+`valomap_bans.json` has no environment override and remains at its existing
+working-directory-relative path.
+
+## Runtime and master-data paths
+
+All JSON and CSV paths exposed through Config use `pathlib.Path`.
+
+| Config field | Existing default |
+|---|---|
+| `valomap_bans_path` | `valomap_bans.json` |
+| `valo_check_data_path` | `data/valo_check_completed.json` |
+| `valo_check_questions_path` | `data/valo_questions.json` |
+| `valo_check_intro_path` | `data/valo_intro.json` |
+| `xmas_gacha_csv_path` | `/home/akitig/Desktop/Bot/Toureikai/Wankorobot/data/2025_xmas_gacha.csv` |
+| `xmas_gacha_state_path` | `/home/akitig/Desktop/Bot/Toureikai/Wankorobot/data/xmas_gacha_state.json` |
+| `joya_data_path` | `data/joya_state.json` |
+| `omikuji_points_path` | `data/2026_omikujii_points.json` |
+
+The current `JOYA_DATA_PATH` default does not match the tracked
+`data/2026_joya_state.json` filename. That pre-existing deployment distinction
+is documented rather than changed in this refactor.

--- a/main.py
+++ b/main.py
@@ -1,10 +1,10 @@
-import os
 import asyncio
 import discord
-from dotenv import load_dotenv
 from discord.ext import commands
 
-load_dotenv()
+from config import get_config
+
+config = get_config()
 intents = discord.Intents.all()
 
 COGS = [
@@ -29,7 +29,7 @@ class MyBot(commands.Bot):
             except Exception as e:
                 print(f"❌ Failed to load {cog}: {e}")
 
-        guild = discord.Object(id=int(os.getenv("GUILD_ID")))
+        guild = discord.Object(id=config.guild_id)
 
         # Cog側の @app_commands.command をギルドに即反映させる
         self.tree.copy_global_to(guild=guild)
@@ -43,7 +43,7 @@ class MyBot(commands.Bot):
 bot = MyBot(
     command_prefix="/",
     intents=intents,
-    application_id=int(os.getenv("APPLICATION_ID")),
+    application_id=config.application_id,
 )
 
 @bot.event
@@ -51,7 +51,7 @@ async def on_ready():
     print(f"✅ Logged in as {bot.user} ({bot.user.id})")
 
 async def main():
-    await bot.start(os.getenv("DISCORD_TOKEN"))
+    await bot.start(config.discord_token)
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from config import get_config
+
+
+def test_config_is_typed_and_cached(monkeypatch) -> None:
+    get_config.cache_clear()
+    monkeypatch.setenv("APPLICATION_ID", "101")
+    monkeypatch.setenv("GUILD_ID", "202")
+    monkeypatch.setenv("DISCORD_TOKEN", "private-token")
+    monkeypatch.setenv("MANAGER_ROLE_IDS", "1,invalid,2")
+    monkeypatch.setenv("VALO_CHECK_DATA_PATH", "runtime/completed.json")
+    monkeypatch.setenv("RR_GAME_VALO", "10:20")
+
+    config = get_config()
+
+    assert config is get_config()
+    assert config.application_id == 101
+    assert config.guild_id == 202
+    assert config.manager_role_ids == frozenset({1, 2})
+    assert config.valo_check_data_path == Path("runtime/completed.json")
+    assert config.reaction_role_values["RR_GAME_VALO"] == "10:20"
+    assert "private-token" not in repr(config)
+
+    get_config.cache_clear()


### PR DESCRIPTION
## Summary

環境変数と設定値の取得を、型付きの `Config` 層へ集約しました。

既存の環境変数名、`.env`、Discord上の動作、runtime JSONの形式と保存場所は変更していません。

## Design

- `config.py` に immutableな `Config` を追加
- `get_config()` をプロセス内でキャッシュ
- `.env` の読込とConfig生成を一度だけ実施
- Discord Tokenを `repr` から除外
- IDを `int` または `int | None` に変換
- ID集合を `frozenset[int]` に変換
- JSON・CSVパスを `pathlib.Path` に変換
- Reaction Role設定を読み取り専用Mappingとして保持
- Cog固有の必須設定はCog生成時に検証

## Changes

- `config.py`
- `tests/test_config.py`
- `docs/architecture/configuration.md`
- `.env.example`
- `README.md`
- `main.py`
- 全10 Cogの環境変数参照

アクティブコードで `os.getenv()`、`os.environ`、`load_dotenv()` を使用するのは `config.py` のみです。

## Tests

Configについて以下を確認しています。

- IDの型変換
- カンマ区切りID集合
- runtime pathの `Path` 化
- `RR_*` 設定の収集
- 同一Configインスタンスのキャッシュ
- Discord Tokenが `repr` に含まれないこと

## Validation

- Ruff: passed
- pytest: 9 passed
- pip check: passed
- compileall: passed
- mainおよび全10 Cogのimport: passed
- git diff --check: passed
- runtime/static JSONのSHA-256: 作業前後で一致
- `.env`変更なし
- Discord接続、Bot起動、systemctl実行なし

## Compatibility

以下を維持しています。

- 既存の環境変数名
- 既存の空文字・未設定時の挙動
- runtime JSONのパスとデータ構造
- Discordコマンドと表示
- Pythonバージョン

## Operational note

Configはプロセス起動時に一度だけ生成されます。

`.env` の変更を反映するにはBotの再起動が必要です。`/rrreload` はキャッシュ済み設定からReaction Roleを再構築し、`.env` 自体は再読込しません。