### PR TITLE
test: add characterization tests for core bot behavior

### DIFF
--- a/cogs/2026_joya_gacha.py
+++ b/cogs/2026_joya_gacha.py
@@ -34,6 +34,21 @@ def _fmt_mmss(sec: int) -> str:
     return f"{m}分{s}秒"
 
 
+def _choose_cooldown(min_sec: int, max_sec: int) -> int:
+    minimum = _clamp(min_sec, 5, 3600)
+    maximum = _clamp(max_sec, 5, 3600)
+    if minimum > maximum:
+        minimum, maximum = maximum, minimum
+    return random.randint(minimum, maximum)
+
+
+def _advance_count(count: int) -> tuple[int, bool]:
+    next_count = count + 1
+    if next_count >= 108:
+        return 108, True
+    return next_count, False
+
+
 def _only_user(user_id: int) -> Callable[[discord.Interaction], bool]:
     def _pred(interaction: discord.Interaction) -> bool:
         return bool(interaction.user and interaction.user.id == user_id)
@@ -308,17 +323,12 @@ class JoyaGacha(commands.Cog):
                 return
 
             cfg = self._get_cfg(guild_id)
-            mn = _clamp(cfg.cd_min_sec, 5, 3600)
-            mx = _clamp(cfg.cd_max_sec, 5, 3600)
-            if mn > mx:
-                mn, mx = mx, mn
-
-            cd = random.randint(mn, mx)
+            cd = _choose_cooldown(cfg.cd_min_sec, cfg.cd_max_sec)
             self._set_cooldown(guild_id, user_id, cd)
             self._store.save()
 
-            count += 1
-            if count < 108:
+            count, finished = _advance_count(count)
+            if not finished:
                 self._set_count_state(guild_id, count, False)
                 await interaction.followup.send(self._normal_msg(count, cd))
                 return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+
+def pytest_configure() -> None:
+    os.environ.setdefault("APPLICATION_ID", "1")
+    os.environ.setdefault("GUILD_ID", "1")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,40 @@
 from pathlib import Path
 
+import pytest
+
+import config as config_module
 from config import get_config
 
 
-def test_config_is_typed_and_cached(monkeypatch) -> None:
+@pytest.fixture(autouse=True)
+def clear_config_cache():
     get_config.cache_clear()
+    yield
+    get_config.cache_clear()
+
+
+def test_required_application_id_is_rejected_when_missing(monkeypatch) -> None:
+    monkeypatch.setattr(config_module, "load_dotenv", lambda: None)
+    monkeypatch.delenv("APPLICATION_ID", raising=False)
+    monkeypatch.setenv("GUILD_ID", "202")
+
+    with pytest.raises(RuntimeError, match="APPLICATION_ID"):
+        get_config()
+
+
+def test_optional_ids_are_none_when_unset(monkeypatch) -> None:
+    monkeypatch.setenv("APPLICATION_ID", "101")
+    monkeypatch.setenv("GUILD_ID", "202")
+    monkeypatch.delenv("DM_FORWARD_USER_ID", raising=False)
+    monkeypatch.delenv("VALO_ROLE_LOG_CHANNEL_ID", raising=False)
+
+    config = get_config()
+
+    assert config.dm_forward_user_id is None
+    assert config.valo_role_log_channel_id is None
+
+
+def test_config_is_typed_and_cached(monkeypatch) -> None:
     monkeypatch.setenv("APPLICATION_ID", "101")
     monkeypatch.setenv("GUILD_ID", "202")
     monkeypatch.setenv("DISCORD_TOKEN", "private-token")
@@ -21,5 +51,3 @@ def test_config_is_typed_and_cached(monkeypatch) -> None:
     assert config.valo_check_data_path == Path("runtime/completed.json")
     assert config.reaction_role_values["RR_GAME_VALO"] == "10:20"
     assert "private-token" not in repr(config)
-
-    get_config.cache_clear()

--- a/tests/test_joya_characterization.py
+++ b/tests/test_joya_characterization.py
@@ -1,0 +1,114 @@
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+joya = importlib.import_module("cogs.2026_joya_gacha")
+
+
+def _cog_with_store(path: Path):
+    cog = joya.JoyaGacha.__new__(joya.JoyaGacha)
+    cog._store = joya._JoyaStore(path)
+    cog._min_env = 60
+    cog._max_env = 300
+    return cog
+
+
+def test_initial_and_saved_state_structure(tmp_path: Path) -> None:
+    path = tmp_path / "joya.json"
+    cog = _cog_with_store(path)
+    store = cog._store
+
+    assert store._data == {"guilds": {}, "users": {}}
+    assert cog._get_count_state(10) == (0, False)
+    assert store.get_guild(10) == {}
+    assert store.get_user(10, 20) == {}
+
+    store.get_guild(10)["count"] = 1
+    store.get_user(10, 20)["next_ts"] = 1234
+    store.save()
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "guilds": {"10": {"count": 1}},
+        "users": {"10:20": {"next_ts": 1234}},
+    }
+
+
+@pytest.mark.parametrize(
+    ("count", "expected"),
+    [
+        (0, (1, False)),
+        (106, (107, False)),
+        (107, (108, True)),
+        (108, (108, True)),
+    ],
+)
+def test_winner_boundary(count: int, expected: tuple[int, bool]) -> None:
+    assert joya._advance_count(count) == expected
+
+
+def test_cooldown_choice_clamps_swaps_and_uses_fixed_random(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[tuple[int, int]] = []
+
+    def fixed_randint(minimum: int, maximum: int) -> int:
+        captured.append((minimum, maximum))
+        return 42
+
+    monkeypatch.setattr(joya.random, "randint", fixed_randint)
+
+    assert joya._choose_cooldown(5000, 2) == 42
+    assert captured == [(5, 3600)]
+
+
+def test_cooldown_remaining_boundaries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    now = 1_000
+    monkeypatch.setattr(joya, "_now_ts", lambda: now)
+    cog = _cog_with_store(tmp_path / "joya.json")
+
+    cog._set_cooldown(10, 20, 30)
+
+    assert cog._cooldown_left(10, 20) == 30
+    monkeypatch.setattr(joya, "_now_ts", lambda: 1_030)
+    assert cog._cooldown_left(10, 20) == 0
+    monkeypatch.setattr(joya, "_now_ts", lambda: 1_031)
+    assert cog._cooldown_left(10, 20) == 0
+
+
+def test_winner_state_persistence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "joya.json"
+    monkeypatch.setattr(joya, "_now_ts", lambda: 1_234_567)
+    cog = _cog_with_store(path)
+
+    cog._set_count_state(10, 108, True, winner_id=20)
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "guilds": {
+            "10": {
+                "count": 108,
+                "finished": True,
+                "winner_user_id": 20,
+                "finished_at": 1_234_567,
+            }
+        },
+        "users": {},
+    }
+
+
+def test_reset_removes_only_target_guild_state(tmp_path: Path) -> None:
+    store = joya._JoyaStore(tmp_path / "joya.json")
+    store.get_guild(10)["count"] = 5
+    store.get_guild(11)["count"] = 6
+    store.get_user(10, 20)["next_ts"] = 100
+    store.get_user(10, 21)["next_ts"] = 200
+    store.get_user(11, 20)["next_ts"] = 300
+
+    assert store.reset_guild_all(10) == 2
+    assert store._data == {
+        "guilds": {"10": {}, "11": {"count": 6}},
+        "users": {"11:20": {"next_ts": 300}},
+    }

--- a/tests/test_omikuji_characterization.py
+++ b/tests/test_omikuji_characterization.py
@@ -1,0 +1,70 @@
+import asyncio
+import importlib
+import json
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+omikuji = importlib.import_module("cogs.2026_omikuji_gacha")
+
+
+def test_point_lifecycle_and_persisted_user_key(tmp_path: Path) -> None:
+    path = tmp_path / "omikuji.json"
+    store = omikuji.OmikujiStore(str(path))
+
+    async def scenario() -> None:
+        await store.load()
+        assert await store.get(12345) == 0
+
+        await store.ensure_initial(12345, 500)
+        await store.ensure_initial(12345, 999)
+        assert await store.get(12345) == 500
+        assert await store.add(12345, 25) == 525
+        assert await store.add(12345, -600) == 0
+
+        await store.ensure_initial(67890, 300)
+        assert await store.reset_all(500) == 2
+        await store.save()
+
+    asyncio.run(scenario())
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "12345": 500,
+        "67890": 500,
+    }
+
+
+def test_load_filters_non_numeric_user_keys(tmp_path: Path) -> None:
+    path = tmp_path / "omikuji.json"
+    path.write_text('{"123": 20, "not-user": 99}', encoding="utf-8")
+    store = omikuji.OmikujiStore(str(path))
+
+    asyncio.run(store.load())
+
+    assert asyncio.run(store.get(123)) == 20
+    assert store._points == {"123": 20}
+
+
+def test_omikuji_weight_table_and_random_choice_are_fixed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[str] = []
+
+    def choose(pool: list[str]) -> str:
+        captured.extend(pool)
+        return "大吉"
+
+    monkeypatch.setattr(omikuji.random, "choice", choose)
+    cog = omikuji.OmikujiGachaCog.__new__(omikuji.OmikujiGachaCog)
+
+    assert cog._draw_omikuji() == "大吉"
+    assert Counter(captured) == {
+        "大吉": 6,
+        "中吉": 14,
+        "小吉": 22,
+        "吉": 26,
+        "末吉": 20,
+        "凶": 10,
+        "大凶": 2,
+    }

--- a/tests/test_valocheck_characterization.py
+++ b/tests/test_valocheck_characterization.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+
+from cogs.valocheck import (
+    DEFAULT_QUESTIONS,
+    ValoCheckCog,
+    _calc_max_score,
+    _normalize_questions,
+)
+
+
+def _role_cog() -> ValoCheckCog:
+    cog = ValoCheckCog.__new__(ValoCheckCog)
+    cog.thresh_enjoy_only = 6
+    cog.thresh_gachi_only = 12
+    cog.label_enjoy = "ENJOY設定"
+    cog.label_gachi = "GACHI設定"
+    cog.label_both = "両方設定"
+    return cog
+
+
+@pytest.mark.parametrize(
+    ("score", "expected"),
+    [
+        (0, (False, True, "ENJOY設定")),
+        (6, (False, True, "ENJOY設定")),
+        (7, (True, True, "両方設定")),
+        (11, (True, True, "両方設定")),
+        (12, (True, False, "GACHI設定")),
+        (18, (True, False, "GACHI設定")),
+    ],
+)
+def test_role_decision_boundaries_and_labels(
+    score: int, expected: tuple[bool, bool, str]
+) -> None:
+    assert _role_cog()._calc_roles(score) == expected
+
+
+def test_every_score_range_assigns_at_least_one_role() -> None:
+    cog = _role_cog()
+
+    for score in range(-10, 31):
+        is_gachi, is_enjoy, _ = cog._calc_roles(score)
+        assert is_gachi or is_enjoy
+
+
+def test_invalid_question_structure_has_no_match() -> None:
+    assert _normalize_questions([]) is None
+    assert _normalize_questions([{"q": "missing choices"}]) is None
+    assert _normalize_questions([{"q": "Q", "choices": [["A", "not-int"]]}]) is None
+
+
+def test_question_scores_are_normalized_and_maximum_is_calculated() -> None:
+    normalized = _normalize_questions(
+        [{"q": " Q ", "choices": [["A", 1], ["B", 3]]}]
+    )
+
+    assert normalized == [{"q": " Q ", "choices": [("A", 1), ("B", 3)]}]
+    assert _calc_max_score(normalized) == 3
+
+
+def test_missing_question_file_uses_built_in_default(tmp_path: Path) -> None:
+    cog = ValoCheckCog.__new__(ValoCheckCog)
+    cog.questions_path = tmp_path / "missing-questions.json"
+    cog.questions = []
+    cog.max_score = 0
+
+    assert cog._reload_questions(use_default=True) is True
+    assert cog.questions is DEFAULT_QUESTIONS
+    assert cog.max_score == _calc_max_score(DEFAULT_QUESTIONS)

--- a/tests/test_xmas_characterization.py
+++ b/tests/test_xmas_characterization.py
@@ -1,0 +1,123 @@
+import importlib
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+xmas = importlib.import_module("cogs.2025_xmas_gacha")
+
+
+def test_initial_state_and_nickname_round_trip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "xmas-state.json"
+    monkeypatch.setattr(xmas, "STATE_PATH", path)
+
+    state = xmas._state_read()
+    assert state == {"orig_nick": {}, "panel_message_id": 0}
+
+    xmas._orig_set(state, 10, 20, "元の名前")
+    xmas._orig_set(state, 10, 21, None)
+    state["panel_message_id"] = 999
+    xmas._state_write(state)
+
+    saved = json.loads(path.read_text(encoding="utf-8"))
+    assert saved == {
+        "orig_nick": {
+            "10": {
+                "20": "元の名前",
+                "21": xmas.STATE_NONE,
+            }
+        },
+        "panel_message_id": 999,
+    }
+    assert xmas._orig_get(saved, 10, 20) == "元の名前"
+    assert xmas._orig_get(saved, 10, 21) == xmas.STATE_NONE
+
+    xmas._orig_clear(saved, 10, 20)
+    assert xmas._orig_get(saved, 10, 20) is None
+
+
+def test_state_read_fills_existing_missing_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "xmas-state.json"
+    path.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(xmas, "STATE_PATH", path)
+
+    assert xmas._state_read() == {"orig_nick": {}, "panel_message_id": 0}
+
+
+def test_csv_reward_parsing_preserves_existing_rules(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "rewards.csv"
+    path.write_text(
+        "weight,rarity,icon,title,name,desc\n"
+        "10,UR,🎁,特賞,犬のお守り,日本語説明\n"
+        "0,R,⭐,重みゼロ,無視,ignored\n"
+        "bad,SR,🌙,不正重み,無視,ignored\n"
+        "5,N,🍪,,タイトルなし,ignored\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(xmas, "CSV_PATH", path)
+
+    assert xmas._read_csv_rewards() == [
+        xmas.t_reward(
+            weight=10,
+            rarity="UR",
+            icon="🎁",
+            title="特賞",
+            name="犬のお守り",
+            desc="日本語説明",
+        )
+    ]
+
+
+def test_weighted_reward_selection_uses_reward_weights(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = xmas.t_reward(2, "R", "", "A", "a", "")
+    second = xmas.t_reward(7, "SR", "", "B", "b", "")
+    captured: dict[str, object] = {}
+
+    def fixed_choices(rewards, *, weights, k):
+        captured.update(rewards=rewards, weights=weights, k=k)
+        return [second]
+
+    monkeypatch.setattr(xmas.random, "choices", fixed_choices)
+
+    assert xmas._pick_reward([first, second]) is second
+    assert captured == {
+        "rewards": [first, second],
+        "weights": [2, 7],
+        "k": 1,
+    }
+
+
+def test_cutoff_is_open_before_and_closed_at_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(xmas, "CUTOFF_RAW", "2025-12-26T07:00:00+09:00")
+
+    monkeypatch.setattr(
+        xmas,
+        "_now_jst",
+        lambda: datetime.fromisoformat("2025-12-26T06:59:59+09:00"),
+    )
+    assert xmas._is_closed() is False
+
+    monkeypatch.setattr(
+        xmas,
+        "_now_jst",
+        lambda: datetime.fromisoformat("2025-12-26T07:00:00+09:00"),
+    )
+    assert xmas._is_closed() is True
+
+    monkeypatch.setattr(
+        xmas,
+        "_now_jst",
+        lambda: datetime.fromisoformat("2025-12-26T07:00:01+09:00"),
+    )
+    assert xmas._is_closed() is True


### PR DESCRIPTION
## Summary

主要5領域の既存挙動を、38件のcharacterization testとして固定しました。

このPRではSQLite移行、機能追加、JSON形式変更、Discord上の仕様変更は行っていません。

## Covered areas

- Config
- VALORANT診断
- おみくじ
- 除夜の鐘
- Xmasガチャ

## Changes

- `tests/conftest.py`
- `tests/test_config.py`
- `tests/test_valocheck_characterization.py`
- `tests/test_omikuji_characterization.py`
- `tests/test_joya_characterization.py`
- `tests/test_xmas_characterization.py`
- `cogs/2026_joya_gacha.py`

## Extracted pure functions

`cogs/2026_joya_gacha.py` から以下を抽出しました。

- `_choose_cooldown`
  - cooldownの範囲制限
  - min/maxの入替
  - 乱数による待機時間決定

- `_advance_count`
  - count加算
  - 108回目のwinner判定

既存handlerも同じ関数を使用し、従来の計算順序と保存形式を維持しています。

## Characterized behavior

### Config

- 必須設定不足時の挙動
- optional ID
- カンマ区切りID集合
- Path変換
- Configキャッシュ
- Tokenのrepr非表示

### VALORANT診断

- ロール判定の全境界
- Config由来のラベル
- 内蔵質問へのフォールバック
- 質問形式と最大スコア

### おみくじ

- 初期ポイント
- ポイント加算・減算・下限
- reset
- User IDの文字列キー
- 保存データ構造
- 確率テーブル

### 除夜の鐘

- 初期state
- Guild/Userキー形式
- cooldownのclampと境界
- 108回目のwinner判定
- winner保存形式
- Guild単位reset

### Xmas

- 初期state
- orig_nickと`__NONE__`
- panel message ID
- CSV解析
- weighted random
- cutoff境界

## Validation

- pytest: 38 passed
- Ruff: passed
- pip check: passed
- compileall: passed
- mainおよび全10 Cogのimport: passed
- git diff --check: passed
- runtime/static JSONのSHA-256: 作業前後で一致
- `.env`変更なし
- Discord接続、Bot起動、systemctl実行なし

## Not covered

Discord APIとの密結合が強い以下は、今後の統合テスト対象です。

- ロール付与・解除
- Interaction応答
- persistent view登録
- VC定期タスク
- VALORANT API通信
- 同時Interaction
- Reaction Role
- Xmasニックネーム変更・復元