### PR TITLE
test: cover Discord boundaries with fakes

### DIFF
--- a/cogs/dm_forward.py
+++ b/cogs/dm_forward.py
@@ -28,13 +28,15 @@ class DmForwardCog(commands.Cog):
             try:
                 target = await self.bot.fetch_user(self.forward_user_id)
             except Exception:
-                logger.exception("Failed to resolve the configured DM forwarding target")
+                logger.exception(
+                    "Failed to resolve the configured DM forwarding target"
+                )
                 return
 
         # 転送本文
         content = message.content or ""
         header = (
-            f"📩 **DM転送**\n"
+            "📩 **DM転送**\n"
             f"From: **{message.author}** (`{message.author.id}`)\n"
         )
 
@@ -48,10 +50,10 @@ class DmForwardCog(commands.Cog):
             logger.exception("Failed to forward a DM message")
             return
 
-        # 添付ファイルも転送（URLだけでもOKならこれで十分）
-        for a in message.attachments[:10]:
+        # 添付ファイルも転送
+        for attachment in message.attachments[:10]:
             try:
-                await target.send(f"📎 添付: {a.url}")
+                await target.send(f"📎 添付: {attachment.url}")
             except Exception:
                 logger.exception("Failed to forward a DM attachment")
 

--- a/cogs/leave_log.py
+++ b/cogs/leave_log.py
@@ -1,12 +1,13 @@
+import asyncio
 import logging
 
 import discord
 from discord.ext import commands
-import asyncio
 
 from config import get_config
 
 logger = logging.getLogger(__name__)
+
 
 class LeaveLog(commands.Cog):
     def __init__(self, bot):
@@ -54,20 +55,41 @@ class LeaveLog(commands.Cog):
         titles = {
             "leave": "📕 退出者が出ました",
             "kick": "🦶 ユーザーが追放されました",
-            "ban": "🕊️ ユーザーがBANされました"
+            "ban": "🕊️ ユーザーがBANされました",
         }
 
         # Embed生成
         embed = discord.Embed(title=titles[event_type], color=color)
-        embed.add_field(name="👤 ユーザー:", value=f"{member.mention}", inline=False)
-        embed.add_field(name="🆔 ID:", value=f"`{member.id}`", inline=False)
-        embed.add_field(name="🎭 退出時ロール:", value=role_list, inline=False)
+        embed.add_field(
+            name="👤 ユーザー:",
+            value=f"{member.mention}",
+            inline=False,
+        )
+        embed.add_field(
+            name="🆔 ID:",
+            value=f"`{member.id}`",
+            inline=False,
+        )
+        embed.add_field(
+            name="🎭 退出時ロール:",
+            value=role_list,
+            inline=False,
+        )
         if reason:
-            embed.add_field(name="📝 理由:", value=reason, inline=False)
-        embed.set_thumbnail(url=member.display_avatar.url if member.display_avatar else None)
+            embed.add_field(
+                name="📝 理由:",
+                value=reason,
+                inline=False,
+            )
+        embed.set_thumbnail(
+            url=member.display_avatar.url if member.display_avatar else None
+        )
 
         await channel.send(embed=embed)
-        logger.info("Leave notification sent: event_type=%s", event_type)
+        logger.info(
+            "Leave notification sent: event_type=%s",
+            event_type,
+        )
 
     # ======================================================
     # ✅ BAN検知イベント
@@ -80,6 +102,7 @@ class LeaveLog(commands.Cog):
         except Exception:
             logger.exception("Failed to fetch ban details")
             reason = "理由なし"
+
         self.recent_bans[user.id] = reason
         logger.info("Member ban event recorded")
 

--- a/cogs/reaction_roles.py
+++ b/cogs/reaction_roles.py
@@ -81,12 +81,16 @@ class ReactionRoles(commands.Cog):
         if not role:
             return
 
-        if add:
-            await member.add_roles(role)
-            logger.info("Reaction Role assigned")
-        else:
-            await member.remove_roles(role)
-            logger.info("Reaction Role removed")
+        try:
+            if add:
+                await member.add_roles(role)
+                logger.info("Reaction Role assigned")
+            else:
+                await member.remove_roles(role)
+                logger.info("Reaction Role removed")
+        except Exception:
+            logger.exception("Reaction Role operation failed")
+            raise
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):

--- a/cogs/welcome.py
+++ b/cogs/welcome.py
@@ -240,16 +240,16 @@ class Welcome(commands.Cog):
                 await ch.send(embed=self.welcome_embed())
                 await ch.send("🧩 **Q1. 25歳以上ですか？**", view=self.Question1(self, member))
             except discord.Forbidden:
-                logger.exception("Bot cannot send messages to a welcome channel")
-                perms = ch.permissions_for(guild.me)
-                logger.debug(
-                    "Welcome channel permissions: view=%s send=%s embed=%s manage=%s",
-                    perms.view_channel,
-                    perms.send_messages,
-                    perms.embed_links,
-                    perms.manage_messages,
-                )
-                return None
+                            logger.exception("Bot cannot send messages to a welcome channel")
+                            perms = ch.permissions_for(guild.me)
+                            logger.debug(
+                                "Welcome channel permissions: view=%s send=%s embed=%s manage=%s",
+                                perms.view_channel,
+                                perms.send_messages,
+                                perms.embed_links,
+                                perms.manage_messages,
+                            )
+                            return None
 
             return ch
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package."""

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test helpers."""

--- a/tests/helpers/discord_fakes.py
+++ b/tests/helpers/discord_fakes.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+
+@dataclass(eq=True, frozen=True)
+class FakeRole:
+    id: int
+    name: str = "test-role"
+
+    @property
+    def mention(self) -> str:
+        return f"<@&{self.id}>"
+
+
+class FakeMember:
+    def __init__(
+        self,
+        user_id: int,
+        *,
+        name: str = "test-member",
+        roles: list[FakeRole] | None = None,
+        bot: bool = False,
+    ) -> None:
+        self.id = user_id
+        self.name = name
+        self.display_name = name
+        self.mention = f"<@{user_id}>"
+        self.roles = list(roles or [])
+        self.bot = bot
+        self.guild: FakeGuild | None = None
+        self.display_avatar = SimpleNamespace(url="https://invalid/avatar.png")
+        self.added_roles: list[tuple[Any, ...]] = []
+        self.removed_roles: list[tuple[Any, ...]] = []
+        self.sent: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+        self.role_error: Exception | None = None
+
+    async def add_roles(self, *roles: Any, **kwargs: Any) -> None:
+        if self.role_error:
+            raise self.role_error
+        self.added_roles.append(roles)
+
+    async def remove_roles(self, *roles: Any, **kwargs: Any) -> None:
+        if self.role_error:
+            raise self.role_error
+        self.removed_roles.append(roles)
+
+    async def send(self, *args: Any, **kwargs: Any) -> FakeSentMessage:
+        self.sent.append((args, kwargs))
+        return FakeSentMessage()
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class FakeSentMessage:
+    def __init__(self) -> None:
+        self.edits: list[dict[str, Any]] = []
+
+    async def edit(self, **kwargs: Any) -> None:
+        self.edits.append(kwargs)
+
+
+class FakeChannel:
+    def __init__(self, *, name: str = "test-channel", send_error: Exception | None = None):
+        self.name = name
+        self.mention = "#test-channel"
+        self.send_error = send_error
+        self.sent: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def send(self, *args: Any, **kwargs: Any) -> FakeSentMessage:
+        if self.send_error:
+            raise self.send_error
+        self.sent.append((args, kwargs))
+        return FakeSentMessage()
+
+
+class FakeGuild:
+    def __init__(
+        self,
+        *,
+        guild_id: int = 100,
+        roles: list[FakeRole] | None = None,
+        members: list[FakeMember] | None = None,
+        channels: dict[int, FakeChannel] | None = None,
+    ) -> None:
+        self.id = guild_id
+        self.roles = list(roles or [])
+        self.members = list(members or [])
+        self._channels = dict(channels or {})
+        self.categories: list[Any] = []
+        self.channels: list[Any] = []
+        self.voice_channels: list[Any] = []
+        self.default_role = FakeRole(0, "@everyone")
+        self.me = FakeMember(999, name="test-bot", bot=True)
+        self.created_categories: list[Any] = []
+        self.created_text_channels: list[FakeChannel] = []
+        self.create_error: Exception | None = None
+        self.channel_send_error: Exception | None = None
+        for member in self.members:
+            member.guild = self
+
+    def get_role(self, role_id: int) -> FakeRole | None:
+        return next((role for role in self.roles if role.id == role_id), None)
+
+    def get_member(self, user_id: int) -> FakeMember | None:
+        return next((member for member in self.members if member.id == user_id), None)
+
+    def get_channel(self, channel_id: int) -> FakeChannel | None:
+        return self._channels.get(channel_id)
+
+    async def create_category(self, name: str) -> Any:
+        if self.create_error:
+            raise self.create_error
+        category = SimpleNamespace(name=name)
+        self.categories.append(category)
+        self.created_categories.append(category)
+        return category
+
+    async def create_text_channel(self, name: str, **kwargs: Any) -> FakeChannel:
+        if self.create_error:
+            raise self.create_error
+        channel = FakeChannel(name=name, send_error=self.channel_send_error)
+        channel.create_kwargs = kwargs
+        self.channels.append(channel)
+        self.created_text_channels.append(channel)
+        return channel
+
+
+class FakeBot:
+    def __init__(self, guild: FakeGuild | None = None) -> None:
+        self.guild = guild
+        self.user = SimpleNamespace(id=999, avatar=None)
+        self.users: dict[int, Any] = {}
+        self.fetch_error: Exception | None = None
+
+    def get_guild(self, guild_id: int) -> FakeGuild | None:
+        if self.guild and self.guild.id == guild_id:
+            return self.guild
+        return None
+
+    def get_user(self, user_id: int) -> Any | None:
+        return self.users.get(user_id)
+
+    async def fetch_user(self, user_id: int) -> Any:
+        if self.fetch_error:
+            raise self.fetch_error
+        return self.users[user_id]
+
+
+class FakeEmoji:
+    def __init__(self, emoji_id: int | None) -> None:
+        self.id = emoji_id
+
+    def is_custom_emoji(self) -> bool:
+        return self.id is not None
+
+
+@dataclass
+class FakePayload:
+    message_id: int
+    user_id: int
+    emoji: FakeEmoji
+
+
+class FakeResponse:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
+
+    async def send_message(self, *args: Any, **kwargs: Any) -> None:
+        self.calls.append(("send_message", args, kwargs))
+
+    async def defer(self, **kwargs: Any) -> None:
+        self.calls.append(("defer", (), kwargs))
+
+    async def edit_message(self, *args: Any, **kwargs: Any) -> None:
+        self.calls.append(("edit_message", args, kwargs))
+
+
+class FakeFollowup:
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    async def send(self, *args: Any, **kwargs: Any) -> None:
+        self.calls.append((args, kwargs))
+
+
+class FakeInteraction:
+    def __init__(self, user: FakeMember, *, guild: FakeGuild | None = None) -> None:
+        self.user = user
+        self.guild = guild
+        self.response = FakeResponse()
+        self.followup = FakeFollowup()
+
+
+@dataclass
+class FakeAuthor:
+    id: int
+    name: str = "private-author"
+    bot: bool = False
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass
+class FakeMessage:
+    author: FakeAuthor
+    channel: Any
+    content: str = ""
+    attachments: list[Any] = field(default_factory=list)
+
+
+class FakeDMChannel:
+    pass

--- a/tests/test_dm_forward_boundaries.py
+++ b/tests/test_dm_forward_boundaries.py
@@ -1,0 +1,117 @@
+import asyncio
+import logging
+
+import pytest
+
+import cogs.dm_forward as dm_module
+from cogs.dm_forward import DmForwardCog
+from tests.helpers.discord_fakes import (
+    FakeAuthor,
+    FakeBot,
+    FakeChannel,
+    FakeDMChannel,
+    FakeMember,
+    FakeMessage,
+)
+
+
+def _cog(bot: FakeBot | None = None) -> DmForwardCog:
+    cog = DmForwardCog.__new__(DmForwardCog)
+    cog.bot = bot or FakeBot()
+    cog.forward_user_id = 700
+    return cog
+
+
+def test_direct_message_is_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dm_module.discord, "DMChannel", FakeDMChannel)
+    target = FakeMember(700)
+    bot = FakeBot()
+    bot.users[700] = target
+    message = FakeMessage(
+        FakeAuthor(800),
+        FakeDMChannel(),
+        content="private message body",
+    )
+
+    asyncio.run(_cog(bot).on_message(message))
+
+    assert len(target.sent) == 1
+    assert "private message body" in target.sent[0][0][0]
+
+
+def test_bot_message_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dm_module.discord, "DMChannel", FakeDMChannel)
+    target = FakeMember(700)
+    bot = FakeBot()
+    bot.users[700] = target
+
+    asyncio.run(
+        _cog(bot).on_message(
+            FakeMessage(FakeAuthor(800, bot=True), FakeDMChannel(), content="ignored")
+        )
+    )
+
+    assert target.sent == []
+
+
+def test_guild_message_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dm_module.discord, "DMChannel", FakeDMChannel)
+    target = FakeMember(700)
+    bot = FakeBot()
+    bot.users[700] = target
+
+    asyncio.run(
+        _cog(bot).on_message(
+            FakeMessage(FakeAuthor(800), FakeChannel(), content="guild content")
+        )
+    )
+
+    assert target.sent == []
+
+
+def test_missing_forward_target_is_logged_without_message_body(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(dm_module.discord, "DMChannel", FakeDMChannel)
+    bot = FakeBot()
+    bot.fetch_error = LookupError("target missing")
+    body = "do-not-log-this-body"
+
+    with caplog.at_level(logging.ERROR):
+        asyncio.run(
+            _cog(bot).on_message(
+                FakeMessage(FakeAuthor(800), FakeDMChannel(), content=body)
+            )
+        )
+
+    assert "Failed to resolve DM forwarding target" in caplog.text
+    assert body not in caplog.text
+
+
+def test_send_failure_is_logged_without_author_or_body(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(dm_module.discord, "DMChannel", FakeDMChannel)
+    target = FakeMember(700)
+
+    async def fail_send(*args, **kwargs):
+        raise RuntimeError("transport unavailable")
+
+    target.send = fail_send
+    bot = FakeBot()
+    bot.users[700] = target
+    author = FakeAuthor(800, name="private-member-name")
+    body = "private-message-body"
+
+    with caplog.at_level(logging.ERROR):
+        asyncio.run(
+            _cog(bot).on_message(
+                FakeMessage(author, FakeDMChannel(), content=body)
+            )
+        )
+
+    assert "Failed to forward direct message" in caplog.text
+    assert author.name not in caplog.text
+    assert body not in caplog.text

--- a/tests/test_leave_log_boundaries.py
+++ b/tests/test_leave_log_boundaries.py
@@ -1,0 +1,130 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+import cogs.leave_log as leave_module
+from cogs.leave_log import LeaveLog
+from tests.helpers.discord_fakes import FakeChannel, FakeGuild, FakeMember, FakeRole
+
+
+def _cog(channel: FakeChannel | None) -> LeaveLog:
+    cog = LeaveLog.__new__(LeaveLog)
+    cog.LEAVE_LOG_CHANNEL_ID = 700
+    cog.recent_bans = {}
+    cog.recent_kicks = {}
+    return cog
+
+
+def _member(channel: FakeChannel | None) -> tuple[FakeMember, FakeGuild]:
+    guild = FakeGuild(
+        guild_id=100,
+        channels={700: channel} if channel else {},
+    )
+    member = FakeMember(500, name="private-member", roles=[guild.default_role, FakeRole(9)])
+    member.guild = guild
+    return member, guild
+
+
+@pytest.fixture
+def no_leave_delay(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def no_sleep(seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(leave_module.asyncio, "sleep", no_sleep)
+
+
+@pytest.mark.parametrize(
+    ("state_name", "expected_title"),
+    [
+        (None, "📕 退出者が出ました"),
+        ("recent_kicks", "🦶 ユーザーが追放されました"),
+        ("recent_bans", "🕊️ ユーザーがBANされました"),
+    ],
+)
+def test_leave_kick_and_ban_notifications(
+    state_name: str | None,
+    expected_title: str,
+    no_leave_delay: None,
+) -> None:
+    channel = FakeChannel()
+    member, _guild = _member(channel)
+    cog = _cog(channel)
+    if state_name:
+        getattr(cog, state_name)[member.id] = "private-reason"
+
+    asyncio.run(cog.on_member_remove(member))
+
+    embed = channel.sent[0][1]["embed"]
+    assert embed.title == expected_title
+    if state_name:
+        assert any(field.value == "private-reason" for field in embed.fields)
+
+
+def test_missing_notification_channel_logs_warning_without_member(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    member, _guild = _member(None)
+    cog = _cog(None)
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(cog.on_member_remove(member))
+
+    assert "Leave notification channel is unavailable" in caplog.text
+    assert member.name not in caplog.text
+
+
+def test_ban_audit_fetch_failure_uses_default_and_logs_without_member(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    guild = FakeGuild()
+    user = FakeMember(500, name="private-member")
+
+    async def fail_fetch_ban(target):
+        raise RuntimeError("audit unavailable")
+
+    guild.fetch_ban = fail_fetch_ban
+    cog = _cog(FakeChannel())
+
+    with caplog.at_level(logging.ERROR):
+        asyncio.run(cog.on_member_ban(guild, user))
+
+    assert cog.recent_bans[user.id] == "理由なし"
+    assert "Failed to fetch ban details" in caplog.text
+    assert user.name not in caplog.text
+
+
+def test_ban_reason_is_not_written_to_process_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    guild = FakeGuild()
+    user = FakeMember(500, name="private-member")
+
+    async def fetch_ban(target):
+        return SimpleNamespace(reason="private moderation reason")
+
+    guild.fetch_ban = fetch_ban
+    cog = _cog(FakeChannel())
+
+    with caplog.at_level(logging.INFO):
+        asyncio.run(cog.on_member_ban(guild, user))
+
+    assert cog.recent_bans[user.id] == "private moderation reason"
+    assert "private moderation reason" not in caplog.text
+    assert user.name not in caplog.text
+
+
+def test_kick_audit_event_records_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(leave_module.discord, "User", FakeMember)
+    target = FakeMember(500)
+    entry = SimpleNamespace(
+        action=leave_module.discord.AuditLogAction.kick,
+        target=target,
+        reason="policy reason",
+    )
+    cog = _cog(FakeChannel())
+
+    asyncio.run(cog.on_audit_log_entry_create(entry))
+
+    assert cog.recent_kicks[target.id] == "policy reason"

--- a/tests/test_reaction_roles_boundaries.py
+++ b/tests/test_reaction_roles_boundaries.py
@@ -1,0 +1,110 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from cogs.reaction_roles import GAME_REACTION_ROLES, ReactionRoles
+from tests.helpers.discord_fakes import (
+    FakeBot,
+    FakeEmoji,
+    FakeGuild,
+    FakeInteraction,
+    FakeMember,
+    FakePayload,
+    FakeRole,
+)
+
+
+def _cog(*, member: FakeMember, role: FakeRole | None = None) -> ReactionRoles:
+    guild = FakeGuild(roles=[role] if role else [], members=[member])
+    cog = ReactionRoles.__new__(ReactionRoles)
+    cog.bot = FakeBot(guild)
+    cog.GUILD_ID = guild.id
+    cog.REACTION_ROLE_MESSAGE_IDS = {200}
+    cog.reaction_role_map = {300: 400}
+    return cog
+
+
+def test_custom_emoji_resolves_role_and_adds_it() -> None:
+    role = FakeRole(400)
+    member = FakeMember(500)
+    cog = _cog(member=member, role=role)
+
+    asyncio.run(cog.handle_reaction(FakePayload(200, 500, FakeEmoji(300)), add=True))
+
+    assert member.added_roles == [(role,)]
+    assert member.removed_roles == []
+
+
+def test_custom_emoji_resolves_role_and_removes_it() -> None:
+    role = FakeRole(400)
+    member = FakeMember(500, roles=[role])
+    cog = _cog(member=member, role=role)
+
+    asyncio.run(cog.handle_reaction(FakePayload(200, 500, FakeEmoji(300)), add=False))
+
+    assert member.removed_roles == [(role,)]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        FakePayload(201, 500, FakeEmoji(300)),
+        FakePayload(200, 500, FakeEmoji(301)),
+        FakePayload(200, 500, FakeEmoji(None)),
+    ],
+)
+def test_unrelated_reaction_does_nothing(payload: FakePayload) -> None:
+    member = FakeMember(500)
+    cog = _cog(member=member, role=FakeRole(400))
+
+    asyncio.run(cog.handle_reaction(payload))
+
+    assert member.added_roles == []
+    assert member.removed_roles == []
+
+
+def test_missing_role_does_nothing() -> None:
+    member = FakeMember(500)
+    cog = _cog(member=member)
+
+    asyncio.run(cog.handle_reaction(FakePayload(200, 500, FakeEmoji(300))))
+
+    assert member.added_roles == []
+
+
+def test_role_permission_error_is_logged_and_propagated(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    member = FakeMember(500, name="private-member")
+    member.role_error = PermissionError("missing role permission")
+    cog = _cog(member=member, role=FakeRole(400))
+
+    with caplog.at_level(logging.ERROR), pytest.raises(PermissionError):
+        asyncio.run(cog.handle_reaction(FakePayload(200, 500, FakeEmoji(300))))
+
+    assert "Reaction Role operation failed" in caplog.text
+    assert "private-member" not in caplog.text
+
+
+def test_reaction_role_command_metadata_and_keys_are_stable() -> None:
+    assert ReactionRoles.rrcreate.name == "rrcreate"
+    assert (
+        ReactionRoles.rrcreate.description
+        == "よく遊ぶゲームを選ぶリアクションメッセージを作成します"
+    )
+    assert GAME_REACTION_ROLES["valo"] == ("VALO民", "RR_GAME_VALO")
+
+
+def test_rrcreate_permission_denial_is_ephemeral() -> None:
+    member = FakeMember(500)
+    member.guild_permissions = SimpleNamespace(administrator=False)
+    interaction = FakeInteraction(member)
+    cog = _cog(member=member, role=FakeRole(400))
+
+    asyncio.run(ReactionRoles.rrcreate.callback(cog, interaction))
+
+    assert interaction.response.calls == [
+        ("send_message", ("⛔ 管理者のみ実行可",), {"ephemeral": True})
+    ]

--- a/tests/test_valocheck_boundaries.py
+++ b/tests/test_valocheck_boundaries.py
@@ -1,0 +1,171 @@
+import asyncio
+import logging
+
+import pytest
+
+from cogs.valocheck import QuizView, ValoCheckCog
+from tests.helpers.discord_fakes import (
+    FakeBot,
+    FakeGuild,
+    FakeInteraction,
+    FakeMember,
+    FakeRole,
+)
+
+
+def _cog(guild: FakeGuild | None = None) -> ValoCheckCog:
+    cog = ValoCheckCog.__new__(ValoCheckCog)
+    cog.bot = FakeBot(guild)
+    cog.guild_id = guild.id if guild else 100
+    cog.sessions = {}
+    cog.completed = {}
+    cog.questions = [
+        {"q": "Q1", "choices": [("A", 0), ("B", 1)]},
+        {"q": "Q2", "choices": [("A", 0), ("B", 1)]},
+    ]
+    cog.max_score = 2
+    cog.view_timeout_sec = 90
+    cog.role_enjoy_id = 801
+    cog.role_gachi_id = 802
+    cog.thresh_enjoy_only = 0
+    cog.thresh_gachi_only = 2
+    cog.label_enjoy = "Enjoy"
+    cog.label_gachi = "Gachi"
+    cog.label_both = "Both"
+    cog.log_channel_id = None
+    cog.admin_dm_user_id = None
+    return cog
+
+
+def test_valo_role_initial_response_is_ephemeral_and_session_is_created() -> None:
+    guild = FakeGuild(guild_id=100)
+    member = FakeMember(500)
+    invoker = FakeMember(600)
+    interaction = FakeInteraction(invoker, guild=guild)
+    cog = _cog(guild)
+
+    async def fake_send_intro(user):
+        cog.sessions[user.id]["dm_message"] = "sent"
+
+    cog._send_intro = fake_send_intro
+
+    asyncio.run(
+        ValoCheckCog.valo_role.callback(cog, interaction, member, force=False)
+    )
+
+    assert interaction.response.calls == [("defer", (), {"ephemeral": True})]
+    assert member.id in cog.sessions
+    assert cog.sessions[member.id]["idx"] == -1
+    assert cog.sessions[member.id]["force_enjoy"] is False
+    assert interaction.followup.calls[-1][1]["ephemeral"] is True
+
+
+def test_last_questions_zero_score_sets_force_enjoy_and_finalizes() -> None:
+    member = FakeMember(500)
+    interaction = FakeInteraction(member)
+    cog = _cog()
+    session = {
+        "idx": 1,
+        "score": 1,
+        "answers": [],
+        "questions": cog.questions,
+    }
+    cog.sessions[member.id] = session
+    finalized: list[dict] = []
+
+    async def fake_finalize(user, state):
+        finalized.append(state.copy())
+
+    cog._finalize = fake_finalize
+
+    asyncio.run(cog.on_answer(interaction, 0, "A"))
+
+    assert finalized[0]["force_enjoy"] is True
+    assert finalized[0]["score"] == 1
+    assert member.id not in cog.sessions
+
+
+def test_finalize_removes_old_roles_and_adds_force_enjoy_role() -> None:
+    enjoy = FakeRole(801, "Enjoy")
+    gachi = FakeRole(802, "Gachi")
+    member = FakeMember(500, roles=[enjoy, gachi])
+    guild = FakeGuild(guild_id=100, roles=[enjoy, gachi], members=[member])
+    cog = _cog(guild)
+    cog._save_completed = lambda: None
+
+    async def no_log(*args):
+        return None
+
+    cog._log_to_channel = no_log
+    state = {
+        "score": 2,
+        "answers": [],
+        "questions": cog.questions,
+        "force_enjoy": True,
+        "forced": False,
+    }
+
+    asyncio.run(cog._finalize(member, state))
+
+    assert member.removed_roles == [(enjoy, gachi)]
+    assert member.added_roles == [(enjoy,)]
+    assert cog.completed[str(member.id)]["result"] == "Enjoy"
+    assert cog.completed[str(member.id)]["force_enjoy"] is True
+
+
+def test_missing_role_notifies_user_without_mutating_completed_data() -> None:
+    member = FakeMember(500)
+    guild = FakeGuild(guild_id=100, roles=[], members=[member])
+    cog = _cog(guild)
+    notices: list[str] = []
+
+    async def capture_notice(title, user_id, state, origin):
+        notices.append(title)
+
+    cog._notify_admin_session = capture_notice
+
+    asyncio.run(cog._finalize(member, {"score": 0, "answers": []}))
+
+    assert notices == ["❌ VALO診断: ロールID不正"]
+    assert member.sent[0][0] == ("ロールID設定が正しくないみたい。運営に連絡してね。",)
+    assert cog.completed == {}
+
+
+def test_role_api_failure_is_logged_without_member_name(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    enjoy = FakeRole(801)
+    gachi = FakeRole(802)
+    member = FakeMember(500, name="private-member", roles=[gachi])
+    member.role_error = RuntimeError("role API unavailable")
+    guild = FakeGuild(guild_id=100, roles=[enjoy, gachi], members=[member])
+    cog = _cog(guild)
+
+    async def no_notice(*args, **kwargs):
+        return None
+
+    cog._notify_admin_session = no_notice
+
+    with caplog.at_level(logging.ERROR):
+        asyncio.run(cog._finalize(member, {"score": 0, "answers": []}))
+
+    assert "Failed to update diagnostic roles" in caplog.text
+    assert member.name not in caplog.text
+    assert cog.completed == {}
+
+
+def test_command_metadata_permission_check_and_view_timeout_are_stable() -> None:
+    cog = _cog()
+
+    async def make_view() -> QuizView:
+        return QuizView(cog, user_id=500, timeout_sec=90)
+
+    view = asyncio.run(make_view())
+
+    assert ValoCheckCog.valo_role.name == "valo_role"
+    assert (
+        ValoCheckCog.valo_role.description
+        == "管理者が指定したメンバーにDMで診断を送ります"
+    )
+    assert len(ValoCheckCog.valo_role.checks) == 1
+    assert view.timeout == 90

--- a/tests/test_welcome_boundaries.py
+++ b/tests/test_welcome_boundaries.py
@@ -1,0 +1,101 @@
+import asyncio
+import logging
+
+import pytest
+
+import cogs.welcome as welcome_module
+from cogs.welcome import Welcome
+from tests.helpers.discord_fakes import FakeBot, FakeGuild, FakeMember, FakeRole
+
+
+class FakeForbidden(Exception):
+    pass
+
+
+def _cog(guild: FakeGuild) -> Welcome:
+    cog = Welcome.__new__(Welcome)
+    cog.bot = FakeBot(guild)
+    cog.user_answers = {}
+    cog.processing_users = set()
+    cog.GUILD_ID = guild.id
+    cog.ADMIN_ID = 700
+    cog.ROLE_A = 801
+    cog.ROLE_B = 802
+    cog.ROLE_C = 803
+    cog.WELCOME_CATEGORY_NAME = "welcome"
+    cog.LOG_CATEGORY_NAME = "log"
+    cog.MANAGER_ROLE_IDS = {900}
+    return cog
+
+
+def test_configured_guild_is_used_and_welcome_messages_are_sent() -> None:
+    guild = FakeGuild(guild_id=100)
+    member = FakeMember(500, name="NewMember")
+
+    channel = asyncio.run(_cog(guild).create_welcome_room(member))
+
+    assert channel is guild.created_text_channels[0]
+    assert guild.created_categories[0].name == "welcome"
+    assert channel.name == "welcome-newmember"
+    assert len(channel.sent) == 3
+    assert member.mention in channel.sent[0][0][0]
+
+
+def test_staff_role_selects_welcome_staff(monkeypatch: pytest.MonkeyPatch) -> None:
+    staff_role = FakeRole(801)
+    staff = FakeMember(501, roles=[staff_role])
+    guild = FakeGuild(guild_id=100, roles=[staff_role], members=[staff])
+    member = FakeMember(500)
+    monkeypatch.setattr(welcome_module.random, "choice", lambda values: values[0])
+    cog = _cog(guild)
+
+    asyncio.run(cog.create_welcome_room(member))
+
+    assert cog.user_answers[member.id]["staff_id"] == staff.id
+
+
+def test_missing_staff_roles_falls_back_to_admin_and_still_sends() -> None:
+    guild = FakeGuild(guild_id=100)
+    member = FakeMember(500)
+    cog = _cog(guild)
+
+    channel = asyncio.run(cog.create_welcome_room(member))
+
+    assert cog.user_answers[member.id]["staff_id"] == cog.ADMIN_ID
+    assert len(channel.sent) == 3
+
+
+def test_permission_failure_logs_no_member_name_or_message_body(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(welcome_module.discord, "Forbidden", FakeForbidden)
+    guild = FakeGuild(guild_id=100)
+    guild.channel_send_error = FakeForbidden("private transport detail")
+    member = FakeMember(500, name="private-member-name")
+
+    with caplog.at_level(logging.ERROR):
+        channel = asyncio.run(_cog(guild).create_welcome_room(member))
+
+    assert channel is None
+    assert "Bot cannot send messages to a welcome channel" in caplog.text
+    assert member.name not in caplog.text
+    assert member.mention not in caplog.text
+
+
+def test_welcome_command_metadata_and_ephemeral_permission_denial() -> None:
+    guild = FakeGuild(guild_id=100)
+    cog = _cog(guild)
+    invoking_member = FakeMember(600)
+    target = FakeMember(500)
+
+    from tests.helpers.discord_fakes import FakeInteraction
+
+    interaction = FakeInteraction(invoking_member, guild=guild)
+    asyncio.run(Welcome.welcome_slash.callback(cog, interaction, target))
+
+    assert Welcome.welcome_slash.name == "welcome"
+    assert Welcome.welcome_slash.description == "指定したユーザーのwelcome部屋を作成します"
+    assert interaction.response.calls == [
+        ("send_message", ("⛔ 管理者のみ実行可",), {"ephemeral": True})
+    ]


### PR DESCRIPTION
## Summary

主要5 CogのDiscord境界動作を、Discordへ接続しないFakeオブジェクトによる32件のテストで固定しました。

実Discordオブジェクト、Discord Token、本番IDは使用していません。

## Covered Cogs

- Reaction Role
- Welcome
- DM Forward
- Leave Log
- VALORANT診断

## Test infrastructure

`tests/helpers/discord_fakes.py` に必要最小限のFakeを追加しました。

- FakeBot
- FakeGuild
- FakeMember
- FakeRole
- FakeChannel
- FakeMessage
- FakeInteraction
- FakeResponse
- FakeFollowup
- FakePayload
- FakeEmoji
- FakeDMChannel

Role操作、Channel送信、Interaction応答、例外注入、呼び出し履歴をDiscord接続なしで検証できます。

## Covered behavior

### Reaction Role

- emojiからRole解決
- Role追加・削除
- 対象外イベント
- Role不存在
- Discord API例外
- command metadata
- 管理者拒否時のephemeral応答

### Welcome

- 対象Guild
- Category・Channel作成
- welcomeメッセージ送信
- 担当Roleによるスタッフ選出
- Role不存在時のfallback
- 権限不足
- command metadataとephemeral

### DM Forward

- DM転送
- BotメッセージとGuildメッセージの除外
- 転送先不存在
- 送信失敗
- DM本文や送信者名をログへ出さないこと

### Leave Log

- 通常退出
- Kick
- Ban
- Audit Log取得不能
- 通知Channel不存在
- Member名と理由をプロセスログへ出さないこと

### VALORANT診断

- 初期deferのephemeral
- セッション生成
- followup応答
- force_enjoy
- Role差し替え
- Role不存在
- Discord API例外
- command metadataとView timeout

## Production code changes

テスト対象となるDiscord境界へ、標準Loggingを追加しました。

- Reaction Role操作失敗
- DM転送先取得・送信失敗
- Welcome Channel作成・送信失敗
- Leave Logの取得・通知失敗
- VALORANT診断のRole操作失敗

Discord返信文、Embed、コマンド仕様、例外伝播方針は変更していません。

## Validation

- pytest: 70 passed
- Ruff: passed
- pip check: passed
- compileall: passed
- mainおよび全Cog import: passed
- git diff --check: passed
- runtime JSONのSHA-256: 作業前後で一致
- `.env`変更なし
- Discord接続、Bot起動、systemctl実行なし

## Not covered

- discord.py内部のHTTP payloadとGateway変換
- Discord本体によるRole階層判定
- command treeの実同期
- Welcome Viewの再起動後永続化
- VALORANT Mapの外部HTTP境界
- 優先対象外Cogのpersistent view