### PR TITLE
chore: harden startup and deployment safety

### DIFF
--- a/cogs/reaction_roles.py
+++ b/cogs/reaction_roles.py
@@ -177,22 +177,5 @@ class ReactionRoles(commands.Cog):
         embed.add_field(name="カスタム絵文字 → ロール", value="\n".join(lines), inline=False)
         await interaction.response.send_message(embed=embed, ephemeral=False)
 
-    # ======================================================
-    # 起動時同期
-    # ======================================================
-    @commands.Cog.listener()
-    async def on_ready(self):
-        guild = discord.Object(id=self.GUILD_ID)
-        try:
-            self.bot.tree.add_command(self.rrcreate, guild=guild)
-            self.bot.tree.add_command(self.rrcreate_valorank, guild=guild)
-            self.bot.tree.add_command(self.rrreload, guild=guild)
-            self.bot.tree.add_command(self.rrstatus, guild=guild)
-            await self.bot.tree.sync(guild=guild)
-            logger.info("Reaction Role commands synced")
-        except Exception:
-            logger.exception("Failed to sync Reaction Role commands")
-
-
 async def setup(bot):
     await bot.add_cog(ReactionRoles(bot))

--- a/cogs/valomap.py
+++ b/cogs/valomap.py
@@ -216,24 +216,8 @@ class ValorantMap(commands.Cog):
         embed.set_footer(text="Powered by わんころBot🐶")
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
-    # -------------------------------
-    # 🔹 起動時同期
-    # -------------------------------
     @commands.Cog.listener()
     async def on_ready(self):
-        guild = discord.Object(id=self.config.guild_id)
-        try:
-            self.bot.tree.add_command(self.valomap_all, guild=guild)
-            self.bot.tree.add_command(self.valomap_pool, guild=guild)
-            self.bot.tree.add_command(self.valomap_select, guild=guild)
-            self.bot.tree.add_command(self.valomap_ban_ui, guild=guild)
-            self.bot.tree.add_command(self.valomap_clear, guild=guild)
-            self.bot.tree.add_command(self.valomap_help, guild=guild)
-            synced = await self.bot.tree.sync(guild=guild)
-            logger.info("VALORANT map commands synced: count=%d", len(synced))
-        except Exception:
-            logger.exception("Failed to sync VALORANT map commands")
-
         if not self.cached_maps:
             await self.get_comp_maps()
 

--- a/cogs/welcome.py
+++ b/cogs/welcome.py
@@ -218,20 +218,5 @@ class Welcome(commands.Cog):
             ephemeral=False
         )
 
-    # ------------------------------------------------------
-    # ✅ 起動後同期
-    # ------------------------------------------------------
-    @commands.Cog.listener()
-    async def on_ready(self):
-        guild = discord.Object(id=self.GUILD_ID)
-        try:
-            self.bot.tree.add_command(self.welcome_slash, guild=guild)
-            self.bot.tree.add_command(self.ok_slash, guild=guild)
-            synced = await self.bot.tree.sync(guild=guild)
-            logger.info("Welcome commands synced: count=%d", len(synced))
-        except Exception:
-            logger.exception("Failed to sync welcome commands")
-
-
 async def setup(bot):
     await bot.add_cog(Welcome(bot))

--- a/docs/architecture/runtime-data.md
+++ b/docs/architecture/runtime-data.md
@@ -40,6 +40,54 @@ later migration must preserve and back up the live files, change application
 paths, validate the copied data, and only then remove the old paths from the Git
 index. That migration is intentionally outside this change.
 
+## Production deployment gate
+
+The following mutable runtime files are still tracked by Git:
+
+- `data/valo_check_completed.json`
+- `data/2026_omikujii_points.json`
+- `data/2026_joya_state.json`
+- `data/xmas_gacha_state.json`
+
+The matching `.gitignore` rules only prevent new untracked files from being
+added. They do not protect files already present in the Git index. An in-place
+checkout, pull, reset, archive extraction, or deployment copy can therefore
+replace state written by the running Bot.
+
+Before production deployment, the operator must take a consistent backup of
+all live runtime JSON and complete a restore test in a temporary directory. The
+backup must be retained independently from the Git worktree and application
+rollback artifacts.
+
+### Proposed Git tracking removal
+
+After the live paths have been migrated and verified, a separately reviewed
+change may remove only the runtime paths from the index with `git rm --cached`.
+That change must not delete or replace the live files, and must verify the
+resulting deployment package no longer contains runtime state. This hardening
+change intentionally does not alter the index.
+
+### Proposed worktree-external layout
+
+Prefer a deployment-owned directory such as `/var/lib/wankorobot/`, with one
+subdirectory per feature. Configure every runtime path through the existing
+environment settings, copy the live files while writers are stopped during an
+approved maintenance window, preserve restrictive permissions, and verify the
+service user can create temporary files and atomically replace the destination.
+
+### Deployment and rollback
+
+Do not perform a normal in-place Git deployment while the four files remain
+tracked unless the deployment process has been proven to exclude them. Before
+starting the candidate revision, record SHA-256 hashes and application-level
+counts for the backup and migrated copies. After startup, verify configured
+paths and counts before accepting writes.
+
+Application rollback and data rollback are separate operations. Roll back code
+without copying repository JSON over live state. Restore runtime data only from
+the verified backup, with writers stopped, then recheck hashes, ownership, file
+mode, JSON validity, and expected record counts before restarting the service.
+
 ## Persistence requirements
 
 Future runtime storage must provide:

--- a/main.py
+++ b/main.py
@@ -65,6 +65,8 @@ async def on_ready():
 async def main():
     logger.info("Bot startup requested")
     try:
+        if not config.discord_token:
+            raise RuntimeError("Missing environment variable: DISCORD_TOKEN")
         await bot.start(config.discord_token)
     except Exception:
         logger.critical("Bot startup failed", exc_info=True)

--- a/tests/test_startup_architecture.py
+++ b/tests/test_startup_architecture.py
@@ -1,0 +1,66 @@
+import ast
+import asyncio
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import main
+
+
+def test_all_cogs_import_and_expose_setup() -> None:
+    for module_name in main.COGS:
+        module = importlib.import_module(module_name)
+        assert callable(getattr(module, "setup", None)), module_name
+
+
+def test_all_services_import_without_importing_cogs() -> None:
+    for path in sorted(Path("services").glob("*.py")):
+        importlib.import_module(f"services.{path.stem}")
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        imported = {
+            node.module
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        imported.update(
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Import)
+            for alias in node.names
+        )
+        assert not any(name == "cogs" or name.startswith("cogs.") for name in imported)
+
+
+def test_command_sync_is_centralized_outside_on_ready() -> None:
+    for path in Path("cogs").glob("*.py"):
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                if node.name == "on_ready":
+                    ready_source = ast.get_source_segment(source, node) or ""
+                    assert ".tree.sync(" not in ready_source, path
+                    assert ".tree.add_command(" not in ready_source, path
+
+
+def test_startup_rejects_missing_discord_token_before_connecting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    async def start(token: str) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(main, "config", SimpleNamespace(discord_token=None))
+    monkeypatch.setattr(main.bot, "start", start)
+
+    with pytest.raises(
+        RuntimeError,
+        match="Missing environment variable: DISCORD_TOKEN",
+    ):
+        asyncio.run(main.main())
+
+    assert called is False


### PR DESCRIPTION
## 概要

本番投入前の横断レビューを行い、起動処理とSlash Command同期の安全性を強化しました。

## 主な変更

- Slash Commandの登録・同期を`MyBot.setup_hook()`へ集約
- Cogの`on_ready`再発火による重複同期を防止
- Valomapのマップ取得処理は既存どおり`on_ready`に維持
- `DISCORD_TOKEN`不足時にDiscord接続前に明示的に失敗
- import時はToken不要のためCI互換性を維持
- runtime JSONがGit追跡中であるリスクと移行手順を文書化
- 起動構造・依存関係を検証するテストを追加

## 追加した検証

- 全Cogがimport可能で`setup()`を持つ
- 全Serviceがimport可能
- ServiceからCogへのimportがない
- `on_ready`内に`tree.sync()`または`tree.add_command()`がない
- Token不足時にDiscord接続処理へ進まない

## 検証結果

- pytest: 127 passed
- Leave Log関連: 18件
- Ruff: 成功
- compileall: 成功
- pip check: 成功
- main import: 成功
- 全Cog import: 10/10
- 全Service import: 成功
- 全Cog setup: 10/10
- 循環依存: なし
- GitHub Actions YAML構文: 成功
- git diff --check: 成功
- runtime JSON全6ファイル: SHA-256一致
- `.env`: 変更なし

## このPRでは実施しない事項

- runtime JSONのGit追跡解除
- runtime JSONのworktree外移行
- systemd Unitの`.venv/bin/python`切替
- 本番Bot起動
- systemctl操作
- ログローテーション設定