### PR TITLE
feat: add DISBOARD bump panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,17 @@ LEAVE_LOG_CHANNEL_ID=
 DM_FORWARD_USER_ID=
 
 # ==========================================
+# ✅ DISBOARD BUMP案内パネル
+# ==========================================
+BUMP_CHANNEL_ID=1432640140911575060
+DISBOARD_BOT_ID=302050872383242240
+# Slash Commandメンション用。未設定時は /bump の手動選択を案内します
+DISBOARD_BUMP_COMMAND_ID=947088344167366698
+BUMP_COOLDOWN_SECONDS=7200
+# 設定時はruntime rootより優先するBUMPパネルstate保存先
+BUMP_PANEL_STATE_PATH=
+
+# ==========================================
 # ✅ Reaction Role（ゲームカテゴリー）
 # ==========================================
 REACTION_ROLE_MESSAGE_IDS=

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ logs/
 
 # Mutable runtime state (legacy paths retained until the planned migration)
 valomap_bans.json
+bump_panel_state.json
+data/bump_panel_state.json
 data/2026_joya_state.json
 data/2026_omikujii_points.json
 data/valo_check_completed.json

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ BAN設定は `valomap_bans.json` に永続保存され、Bot再起動後も保�
 > ファイル：`main.py`
 
 Bot全体のエントリーポイント。  
-`.env` の設定を読み込み、以下の10個のCogを起動します。
+`.env` の設定を読み込み、以下の11個のCogを起動します。
 
 ```bash
 cogs/welcome
@@ -87,7 +87,13 @@ cogs/dm_forward
 cogs/2025_xmas_gacha
 cogs/2026_joya_gacha
 cogs/2026_omikuji_gacha
+cogs/bump_panel
 ```
+
+`bump_panel`はDISBOARDのBUMP成功を検知し、2時間後まで1回だけ待機する
+常設案内パネルです。Bot自身は`/bump`を実行せず、ボタンはユーザーへCommand
+メンションをephemeral表示します。Command ID未設定時は手動で`/bump`を選ぶよう
+案内します。
 
 起動時には全スラッシュコマンドを自動同期し、  
 権限エラーやロード失敗もコンソールに出力されます。
@@ -182,7 +188,7 @@ EnvironmentFile=/home/akitig/Desktop/Bot/Toureikai/Wankorobot/.env
 | ライブラリ | discord.py v2.x / aiohttp / python-dotenv |
 | データ保存 | Repository経由のruntime JSON・.env |
 | 実行方式 | systemd 常駐 or CLI実行 |
-| 構造 | 10 Cog / Service層 / Repository層 / storage層 |
+| 構造 | 11 Cog / Service層 / Repository層 / storage層 |
 
 ---
 
@@ -191,7 +197,7 @@ EnvironmentFile=/home/akitig/Desktop/Bot/Toureikai/Wankorobot/.env
 ```text
 cogs/          Discord Command・Interaction・View境界
 services/      業務ロジックとDiscord API操作
-repositories/  機能ごとの永続状態と保存API（5 Repository）
+repositories/  機能ごとの永続状態と保存API（6 Repository）
 storage/       共通のJSON読込・atomic保存
 tests/         characterization・境界・Repository・構造テスト
 ```

--- a/cogs/bump_panel.py
+++ b/cogs/bump_panel.py
@@ -1,0 +1,79 @@
+"""Discord event and persistent-view boundary for the BUMP panel."""
+
+from __future__ import annotations
+
+import discord
+from discord.ext import commands
+
+from config import get_config
+from repositories.bump_panel_repository import BumpPanelRepository
+from services.bump_panel_service import BumpPanelService
+
+
+class BumpPanelView(discord.ui.View):
+    def __init__(self, service: BumpPanelService, *, available: bool) -> None:
+        super().__init__(timeout=None)
+        self._service = service
+        button = self.open_command
+        button.label = "BUMPする" if available else "BUMP待機中"
+        button.style = (
+            discord.ButtonStyle.success
+            if available
+            else discord.ButtonStyle.secondary
+        )
+        button.disabled = not available
+
+    @discord.ui.button(
+        label="BUMPする",
+        style=discord.ButtonStyle.success,
+        custom_id="bump_panel:open_command",
+    )
+    async def open_command(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        await self._service.send_command_guide(interaction)
+
+
+class BumpPanelCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        config = get_config()
+        channel_id = config.require_id(config.bump_channel_id, "BUMP_CHANNEL_ID")
+        disboard_bot_id = config.require_id(
+            config.disboard_bot_id,
+            "DISBOARD_BOT_ID",
+        )
+        repository = BumpPanelRepository(config.bump_panel_state_path)
+        self.service = BumpPanelService(
+            bot=bot,
+            repository=repository,
+            channel_id=channel_id,
+            disboard_bot_id=disboard_bot_id,
+            bump_command_id=config.disboard_bump_command_id,
+            cooldown_seconds=config.bump_cooldown_seconds,
+            view_factory=lambda available: BumpPanelView(
+                self.service,
+                available=available,
+            ),
+        )
+
+    async def cog_load(self) -> None:
+        self.bot.add_view(BumpPanelView(self.service, available=True))
+        await self.service.initialize()
+
+    async def cog_unload(self) -> None:
+        await self.service.shutdown()
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        await self.service.ensure_panel()
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        await self.service.handle_message(message)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(BumpPanelCog(bot))

--- a/config.py
+++ b/config.py
@@ -19,7 +19,8 @@ PRODUCTION_DATA_DIR = Path("/home/akitig/Desktop/Bot/Toureikai/Wankorobot/data")
 
 def resolve_runtime_data_dir(
     environ: Mapping[str, str],
-    home: Path,
+    home: Path | None,
+    data_dir: Path = Path("data"),
 ) -> Path:
     """Resolve the directory containing mutable application state."""
 
@@ -31,7 +32,9 @@ def resolve_runtime_data_dir(
     xdg_data_home = environ.get("XDG_DATA_HOME")
     if xdg_data_home is not None and xdg_data_home.strip():
         return Path(xdg_data_home.strip()) / "wankoro-bot"
-    return home / ".local" / "share" / "wankoro-bot"
+    if home is not None:
+        return home / ".local" / "share" / "wankoro-bot"
+    return data_dir
 
 
 def resolve_runtime_path(
@@ -68,6 +71,11 @@ def _int_with_default(name: str, default: int) -> int:
         return int(value)
     except ValueError:
         return default
+
+
+def _positive_int_with_default(name: str, default: int) -> int:
+    value = _int_with_default(name, default)
+    return value if value > 0 else default
 
 
 def _string_with_default(name: str, default: str, *, strip: bool = False) -> str:
@@ -151,6 +159,12 @@ class Config:
     valo_recruit_enjoy_role_id: int | None
     valo_recruit_cooldown_seconds: int
 
+    bump_channel_id: int | None
+    disboard_bot_id: int | None
+    disboard_bump_command_id: int | None
+    bump_cooldown_seconds: int
+    bump_panel_state_path: Path
+
     def require_id(self, value: int | None, environment_name: str) -> int:
         """Return a required Cog setting or fail when that Cog is constructed."""
 
@@ -161,7 +175,9 @@ class Config:
 
 def _load_config() -> Config:
     load_dotenv()
-    runtime_data_dir = resolve_runtime_data_dir(os.environ, Path.home())
+    home_value = os.environ.get("HOME")
+    home = Path(home_value.strip()) if home_value and home_value.strip() else None
+    runtime_data_dir = resolve_runtime_data_dir(os.environ, home)
     return Config(
         discord_token=os.getenv("DISCORD_TOKEN"),
         application_id=_required_int("APPLICATION_ID"),
@@ -268,6 +284,19 @@ def _load_config() -> Config:
         valo_recruit_cooldown_seconds=_int_with_default(
             "VALO_RECRUIT_COOLDOWN_SECONDS",
             300,
+        ),
+        bump_channel_id=_optional_int("BUMP_CHANNEL_ID"),
+        disboard_bot_id=_optional_int("DISBOARD_BOT_ID"),
+        disboard_bump_command_id=_optional_int("DISBOARD_BUMP_COMMAND_ID"),
+        bump_cooldown_seconds=_positive_int_with_default(
+            "BUMP_COOLDOWN_SECONDS",
+            7200,
+        ),
+        bump_panel_state_path=resolve_runtime_path(
+            explicit_value=os.getenv("BUMP_PANEL_STATE_PATH"),
+            runtime_dir=runtime_data_dir,
+            filename="bump_panel_state.json",
+            strip=True,
         ),
     )
 

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -61,13 +61,15 @@ Repository APIs; a DI container is not needed for the current application.
 | Christmas event | `XMAS_GACHA_CSV`, `XMAS_GACHA_STATE`, `XMAS_GACHA_CHANNEL_ID`, `XMAS_GACHA_CUTOFF` |
 | New Year bell event | `JOYA_DATA_PATH`, `JOYA_MIN_SEC`, `JOYA_MAX_SEC`, `JOYA_WINNER_ROLE_ID`, `JOYA_CHANNEL_ID` |
 | Omikuji event | `OMIKUJI_POINTS_PATH`, `OMIKUJI_REST_VC_ID`, `OMIKUJI_RESETTER_USER_ID`, `OMIKUJI_PANEL_CHANNEL_ID` |
+| DISBOARD BUMP panel | `BUMP_CHANNEL_ID`, `DISBOARD_BOT_ID`, `DISBOARD_BUMP_COMMAND_ID`, `BUMP_COOLDOWN_SECONDS`, `BUMP_PANEL_STATE_PATH` |
 
 Mutable runtime paths use an explicitly configured feature path first. Otherwise,
 their root is resolved in this order: `RUNTIME_DATA_DIR`, `STATE_DIRECTORY`,
-`XDG_DATA_HOME/wankoro-bot`, then `~/.local/share/wankoro-bot`. Empty root values
-are ignored and surrounding whitespace is removed. `STATE_DIRECTORY` is the
-absolute path supplied by systemd and is used directly; Config does not rebuild
-it below `/var/lib`.
+`XDG_DATA_HOME/wankoro-bot`, `~/.local/share/wankoro-bot`, then the existing
+working-directory-relative `data/` directory when no home is available. Empty
+root values are ignored and surrounding whitespace is removed.
+`STATE_DIRECTORY` is the absolute path supplied by systemd and is used directly;
+Config does not rebuild it below `/var/lib`.
 
 Existing feature-specific path whitespace behavior is preserved. Omikuji and
 Xmas paths are stripped; Joya and VALORANT check paths remain literal. An empty
@@ -88,6 +90,7 @@ All JSON and CSV paths exposed through Config use `pathlib.Path`.
 | `xmas_gacha_state_path` | `xmas_gacha_state.json` |
 | `joya_data_path` | `2026_joya_state.json` |
 | `omikuji_points_path` | `2026_omikujii_points.json` |
+| `bump_panel_state_path` | `bump_panel_state.json` |
 
 Resolving Config paths only constructs `Path` values. It does not create the
 runtime directory or any JSON file.

--- a/docs/architecture/repositories.md
+++ b/docs/architecture/repositories.md
@@ -43,6 +43,11 @@ storage/json_store.py
 - **XmasRepository**: 元nicknameとpanel message IDのruntime state永続化。
 - **ValomapRepository**: VALORANTマップのBAN setと追加・解除・全解除の永続化。
 - **ValocheckRepository**: 診断完了recordと質問・introのraw JSON読込。
+- **BumpPanelRepository**: BUMP成功時刻、次回可能時刻、panel message IDの永続化。
+
+BUMPパネルは成功時に次回可能時刻を計算し、その時刻まで単一taskで1回だけ待機します。
+常時ポーリングやDISBOARDコマンドの自動実行、ユーザー代理Interactionは行いません。
+Command IDが未設定の場合は、ユーザーへ`/bump`の手動選択を案内します。
 
 景品CSV、確率、cutoff、スコア、Role判定、マップAPI取得などの業務ルールは、それぞれ
 Serviceの責務です。

--- a/docs/architecture/runtime-data.md
+++ b/docs/architecture/runtime-data.md
@@ -31,6 +31,7 @@ current production layout.
 | `data/2026_joya_state.json` | Runtime state | Yes | Yes: IDs/state | Tracked | `/var/lib/wankorobot/events/2026-joya/state.json` initially |
 | `data/xmas_gacha_state.json` | Runtime state | Yes | Potentially: IDs/nicknames | Tracked | `/var/lib/wankorobot/events/2025-xmas/state.json` initially |
 | `valomap_bans.json` | Runtime state | Yes | No known personal data | Ignored | `/var/lib/wankorobot/valomap/bans.json` |
+| `bump_panel_state.json` | Runtime state | Yes | No user data; timestamps and panel ID only | Ignored | `/var/lib/wankoro-bot/bump_panel_state.json` |
 | `bot.log`, `bot.err` | Log | Yes | May include IDs/names/errors | Ignored | journald or `/var/log/wankorobot/` with rotation |
 | `cogs/__pycache__/` | Generated cache | Yes | No | Ignored | Not deployed/copied |
 | `OLD/` | Historical source | No | Unknown until separately audited | Tracked | `archive/legacy/` or Git history |

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ COGS = [
     "cogs.2025_xmas_gacha",
     "cogs.2026_joya_gacha",
     "cogs.2026_omikuji_gacha",
+    "cogs.bump_panel",
 ]
 
 class MyBot(commands.Bot):

--- a/repositories/bump_panel_repository.py
+++ b/repositories/bump_panel_repository.py
@@ -1,0 +1,108 @@
+"""JSON-backed persistence for the DISBOARD BUMP panel."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from storage.json_store import load_json_or_default, save_json_atomic
+
+INITIAL_STATE: dict[str, Any] = {
+    "last_bumped_at": None,
+    "next_bump_at": None,
+    "panel_message_id": 0,
+}
+
+
+def _parse_datetime(value: object, field_name: str) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a timezone-aware ISO 8601 string")
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ValueError(f"{field_name} contains an invalid datetime") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+    return parsed
+
+
+def _require_aware(value: datetime, field_name: str) -> None:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError(f"{field_name} must be timezone-aware")
+
+
+class BumpPanelRepository:
+    """Own and persist BUMP cooldown and panel identity state."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._state: dict[str, Any] = dict(INITIAL_STATE)
+
+    def load(self) -> None:
+        state = load_json_or_default(self._path, INITIAL_STATE)
+        if not isinstance(state, dict):
+            raise ValueError("BUMP panel state must be a JSON object")
+
+        last_bumped_at = _parse_datetime(
+            state.get("last_bumped_at"),
+            "last_bumped_at",
+        )
+        next_bump_at = _parse_datetime(
+            state.get("next_bump_at"),
+            "next_bump_at",
+        )
+        panel_message_id = state.get("panel_message_id", 0)
+        if isinstance(panel_message_id, bool) or not isinstance(panel_message_id, int):
+            raise ValueError("panel_message_id must be an integer")
+        if panel_message_id < 0:
+            raise ValueError("panel_message_id must not be negative")
+
+        self._state = {
+            "last_bumped_at": (
+                last_bumped_at.isoformat() if last_bumped_at is not None else None
+            ),
+            "next_bump_at": (
+                next_bump_at.isoformat() if next_bump_at is not None else None
+            ),
+            "panel_message_id": panel_message_id,
+        }
+
+    def save(self) -> None:
+        save_json_atomic(self._path, self._state)
+
+    def get_last_bumped_at(self) -> datetime | None:
+        return _parse_datetime(self._state["last_bumped_at"], "last_bumped_at")
+
+    def get_next_bump_at(self) -> datetime | None:
+        return _parse_datetime(self._state["next_bump_at"], "next_bump_at")
+
+    def get_panel_message_id(self) -> int:
+        return int(self._state["panel_message_id"])
+
+    def set_bump_times(
+        self,
+        *,
+        last_bumped_at: datetime,
+        next_bump_at: datetime,
+    ) -> None:
+        _require_aware(last_bumped_at, "last_bumped_at")
+        _require_aware(next_bump_at, "next_bump_at")
+        if next_bump_at < last_bumped_at:
+            raise ValueError("next_bump_at must not precede last_bumped_at")
+        self._state["last_bumped_at"] = last_bumped_at.isoformat()
+        self._state["next_bump_at"] = next_bump_at.isoformat()
+
+    def clear_next_bump_at(self) -> None:
+        self._state["next_bump_at"] = None
+
+    def set_panel_message_id(self, message_id: int) -> None:
+        if (
+            isinstance(message_id, bool)
+            or not isinstance(message_id, int)
+            or message_id < 0
+        ):
+            raise ValueError("panel_message_id must be a non-negative integer")
+        self._state["panel_message_id"] = message_id

--- a/services/bump_panel_service.py
+++ b/services/bump_panel_service.py
@@ -1,0 +1,293 @@
+"""Business workflow for the DISBOARD BUMP guidance panel."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import discord
+
+from repositories.bump_panel_repository import BumpPanelRepository
+
+logger = logging.getLogger(__name__)
+
+_BUMP_SUCCESS_PATTERN = re.compile(
+    r"\bbump(?:ed)?\s+(?:done|complete|completed|success|successful)\b",
+    re.IGNORECASE,
+)
+
+
+def _message_text_fragments(message: Any) -> tuple[str, ...]:
+    fragments: list[str] = []
+    content = getattr(message, "content", None)
+    if isinstance(content, str):
+        fragments.append(content)
+    for embed in getattr(message, "embeds", ()) or ():
+        for value in (
+            getattr(embed, "title", None),
+            getattr(embed, "description", None),
+            getattr(getattr(embed, "author", None), "name", None),
+            getattr(getattr(embed, "footer", None), "text", None),
+        ):
+            if isinstance(value, str):
+                fragments.append(value)
+    return tuple(fragments)
+
+
+def is_bump_success_message(
+    message: Any,
+    *,
+    channel_id: int,
+    disboard_bot_id: int,
+) -> bool:
+    """Conservatively identify a successful DISBOARD ``/bump`` response."""
+
+    if getattr(getattr(message, "channel", None), "id", None) != channel_id:
+        return False
+    if getattr(getattr(message, "author", None), "id", None) != disboard_bot_id:
+        return False
+
+    metadata = getattr(message, "interaction_metadata", None)
+    command_name = getattr(metadata, "name", None)
+    if not isinstance(command_name, str):
+        interaction = getattr(message, "interaction", None)
+        command_name = getattr(interaction, "name", None)
+    if isinstance(command_name, str):
+        return command_name.casefold() == "bump"
+
+    for fragment in _message_text_fragments(message):
+        normalized = fragment.casefold()
+        if _BUMP_SUCCESS_PATTERN.search(normalized):
+            return True
+        if "bump" in normalized and ("成功" in fragment or "完了" in fragment):
+            return True
+        if "表示順をアップ" in fragment:
+            return True
+    return False
+
+
+class BumpPanelService:
+    """Coordinate BUMP state, one-shot cooldown scheduling, and panel I/O."""
+
+    def __init__(
+        self,
+        *,
+        bot: Any,
+        repository: BumpPanelRepository,
+        channel_id: int,
+        disboard_bot_id: int,
+        bump_command_id: int | None,
+        cooldown_seconds: int,
+        view_factory: Callable[[bool], discord.ui.View],
+        now_factory: Callable[[], datetime] | None = None,
+        sleep_func: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        if cooldown_seconds <= 0:
+            raise ValueError("cooldown_seconds must be positive")
+        self.bot = bot
+        self._repository = repository
+        self._channel_id = channel_id
+        self._disboard_bot_id = disboard_bot_id
+        self._bump_command_id = bump_command_id
+        self._cooldown_seconds = cooldown_seconds
+        self._view_factory = view_factory
+        self._now_factory = now_factory or (lambda: datetime.now(timezone.utc))
+        self._sleep = sleep_func
+        self._cooldown_task: asyncio.Task[None] | None = None
+        self._loaded = False
+
+    def _now(self) -> datetime:
+        now = self._now_factory()
+        if now.tzinfo is None or now.utcoffset() is None:
+            raise ValueError("now_factory must return a timezone-aware datetime")
+        return now
+
+    def is_available(self, now: datetime | None = None) -> bool:
+        current = now or self._now()
+        next_bump_at = self._repository.get_next_bump_at()
+        return next_bump_at is None or next_bump_at <= current
+
+    @staticmethod
+    def panel_embed(next_bump_at: datetime | None) -> discord.Embed:
+        if next_bump_at is None:
+            return discord.Embed(
+                title="🟢 BUMPできます",
+                description=(
+                    "サーバーを上位表示できます。\n"
+                    "下のボタンからBUMPコマンドを開いてください。"
+                ),
+                color=discord.Color.green(),
+            )
+        unix_time = int(next_bump_at.timestamp())
+        return discord.Embed(
+            title="⏳ BUMP待機中",
+            description=f"次回BUMP可能：<t:{unix_time}:R>",
+            color=discord.Color.greyple(),
+        )
+
+    async def initialize(self) -> None:
+        if not self._loaded:
+            self._repository.load()
+            self._loaded = True
+            logger.info("BUMP panel state loaded")
+
+        next_bump_at = self._repository.get_next_bump_at()
+        now = self._now()
+        if next_bump_at is not None and next_bump_at <= now:
+            self._repository.clear_next_bump_at()
+            self._repository.save()
+            next_bump_at = None
+        await self.ensure_panel()
+        if next_bump_at is not None:
+            self._schedule_cooldown(next_bump_at)
+
+    def _get_channel(self) -> Any | None:
+        channel = self.bot.get_channel(self._channel_id)
+        if channel is None:
+            logger.warning("BUMP panel channel is unavailable")
+        return channel
+
+    async def ensure_panel(self) -> None:
+        channel = self._get_channel()
+        if channel is None:
+            return
+        next_bump_at = self._repository.get_next_bump_at()
+        message_id = self._repository.get_panel_message_id()
+        if message_id:
+            try:
+                message = await channel.fetch_message(message_id)
+            except discord.NotFound:
+                logger.warning("Stored BUMP panel message was not found")
+            except (discord.Forbidden, discord.HTTPException):
+                logger.exception("Failed to fetch the BUMP panel message")
+                return
+            else:
+                try:
+                    await message.edit(
+                        embed=self.panel_embed(next_bump_at),
+                        view=self._view_factory(next_bump_at is None),
+                    )
+                except (discord.Forbidden, discord.HTTPException):
+                    logger.exception("Failed to update the BUMP panel")
+                    return
+                logger.info("BUMP panel updated")
+                return
+        await self._create_panel(channel, next_bump_at)
+
+    async def _create_panel(
+        self,
+        channel: Any,
+        next_bump_at: datetime | None,
+    ) -> None:
+        try:
+            message = await channel.send(
+                embed=self.panel_embed(next_bump_at),
+                view=self._view_factory(next_bump_at is None),
+            )
+        except (discord.Forbidden, discord.HTTPException):
+            logger.exception("Failed to create the BUMP panel")
+            return
+        self._repository.set_panel_message_id(message.id)
+        try:
+            self._repository.save()
+        except Exception:
+            logger.exception("Failed to save the BUMP panel state after panel creation")
+            raise
+        logger.info("BUMP panel created")
+
+    async def handle_message(self, message: Any) -> None:
+        if not is_bump_success_message(
+            message,
+            channel_id=self._channel_id,
+            disboard_bot_id=self._disboard_bot_id,
+        ):
+            if (
+                getattr(getattr(message, "channel", None), "id", None)
+                == self._channel_id
+                and getattr(getattr(message, "author", None), "id", None)
+                == self._disboard_bot_id
+            ):
+                logger.warning("Unable to confirm a DISBOARD BUMP response")
+            return
+        await self.record_bump_success()
+
+    async def record_bump_success(self) -> None:
+        now = self._now()
+        next_bump_at = now + timedelta(seconds=self._cooldown_seconds)
+        self._repository.set_bump_times(
+            last_bumped_at=now,
+            next_bump_at=next_bump_at,
+        )
+        try:
+            self._repository.save()
+        except Exception:
+            logger.exception("Failed to save the BUMP cooldown state")
+            raise
+        logger.info("BUMP cooldown started")
+        self._schedule_cooldown(next_bump_at)
+        await self._repost_waiting_panel(next_bump_at)
+
+    async def _repost_waiting_panel(self, next_bump_at: datetime) -> None:
+        channel = self._get_channel()
+        if channel is None:
+            return
+        message_id = self._repository.get_panel_message_id()
+        if message_id:
+            try:
+                old_message = await channel.fetch_message(message_id)
+                await old_message.delete()
+            except discord.NotFound:
+                logger.warning("Stored BUMP panel message was not found")
+            except (discord.Forbidden, discord.HTTPException):
+                logger.exception("Failed to delete the previous BUMP panel")
+        await self._create_panel(channel, next_bump_at)
+
+    def _schedule_cooldown(self, next_bump_at: datetime) -> None:
+        if self._cooldown_task is not None and not self._cooldown_task.done():
+            self._cooldown_task.cancel()
+        self._cooldown_task = asyncio.create_task(
+            self._wait_for_cooldown(next_bump_at),
+            name="bump-panel-cooldown",
+        )
+
+    async def _wait_for_cooldown(self, next_bump_at: datetime) -> None:
+        try:
+            delay = max(0.0, (next_bump_at - self._now()).total_seconds())
+            await self._sleep(delay)
+            self._repository.clear_next_bump_at()
+            self._repository.save()
+            await self.ensure_panel()
+            logger.info("BUMP cooldown ended")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Unexpected failure in the BUMP cooldown task")
+
+    async def send_command_guide(self, interaction: discord.Interaction) -> None:
+        if self._bump_command_id is None:
+            message = (
+                "このチャンネルで /bump を入力し、\n"
+                "DISBOARDのコマンドを選択してください。"
+            )
+            logger.warning("DISBOARD BUMP command ID is not configured")
+        else:
+            message = f"BUMPはこちら：</bump:{self._bump_command_id}>"
+
+        is_done = getattr(interaction.response, "is_done", lambda: False)
+        if is_done():
+            await interaction.followup.send(message, ephemeral=True)
+        else:
+            await interaction.response.send_message(message, ephemeral=True)
+
+    async def shutdown(self) -> None:
+        task = self._cooldown_task
+        self._cooldown_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task

--- a/tests/test_bump_panel_architecture.py
+++ b/tests/test_bump_panel_architecture.py
@@ -1,0 +1,59 @@
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+COG = ROOT / "cogs" / "bump_panel.py"
+SERVICE = ROOT / "services" / "bump_panel_service.py"
+REPOSITORY = ROOT / "repositories" / "bump_panel_repository.py"
+
+
+def imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    result: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            result.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            result.add(node.module)
+    return result
+
+
+def test_bump_panel_dependency_direction() -> None:
+    assert "services.bump_panel_service" in imports(COG)
+    assert "repositories.bump_panel_repository" in imports(SERVICE)
+    assert "storage.json_store" in imports(REPOSITORY)
+    assert not any(name.startswith("cogs") for name in imports(SERVICE))
+    forbidden = {"config", "discord", "aiohttp", "services", "cogs"}
+    assert not {
+        name
+        for name in imports(REPOSITORY)
+        if any(name == item or name.startswith(f"{item}.") for item in forbidden)
+    }
+
+
+def test_only_repository_imports_json_storage() -> None:
+    assert "storage.json_store" not in imports(COG)
+    assert "storage.json_store" not in imports(SERVICE)
+    assert "storage.json_store" in imports(REPOSITORY)
+
+
+def test_service_and_repository_do_not_read_environment() -> None:
+    for path in (SERVICE, REPOSITORY):
+        source = path.read_text(encoding="utf-8")
+        assert "get_config" not in source
+        assert "os.getenv" not in source
+        assert "os.environ" not in source
+        assert "load_dotenv" not in source
+
+
+def test_persistent_view_is_not_registered_in_on_ready() -> None:
+    source = COG.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(COG))
+    on_ready = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "on_ready"
+    )
+    ready_source = ast.get_source_segment(source, on_ready) or ""
+    assert "add_view" not in ready_source
+    assert "tree.sync" not in ready_source

--- a/tests/test_bump_panel_boundaries.py
+++ b/tests/test_bump_panel_boundaries.py
@@ -1,0 +1,131 @@
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import discord
+
+import cogs.bump_panel as bump_cog
+import main
+
+
+class ServiceFake:
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.calls: list[tuple[object, ...]] = []
+
+    async def initialize(self) -> None:
+        self.calls.append(("initialize",))
+
+    async def shutdown(self) -> None:
+        self.calls.append(("shutdown",))
+
+    async def ensure_panel(self) -> None:
+        self.calls.append(("ensure_panel",))
+
+    async def handle_message(self, message: object) -> None:
+        self.calls.append(("handle_message", message))
+
+    async def send_command_guide(self, interaction: object) -> None:
+        self.calls.append(("send_command_guide", interaction))
+
+
+class BotFake:
+    def __init__(self) -> None:
+        self.views: list[discord.ui.View] = []
+        self.cogs: list[object] = []
+
+    def add_view(self, view: discord.ui.View) -> None:
+        self.views.append(view)
+
+    async def add_cog(self, cog: object) -> None:
+        self.cogs.append(cog)
+
+
+def config(tmp_path: Path) -> SimpleNamespace:
+    return SimpleNamespace(
+        bump_channel_id=10,
+        disboard_bot_id=20,
+        disboard_bump_command_id=30,
+        bump_cooldown_seconds=7200,
+        bump_panel_state_path=tmp_path / "bump.json",
+        require_id=lambda value, _name: value,
+    )
+
+
+def make_cog(tmp_path: Path, monkeypatch) -> tuple[bump_cog.BumpPanelCog, BotFake]:
+    monkeypatch.setattr(bump_cog, "get_config", lambda: config(tmp_path))
+    monkeypatch.setattr(bump_cog, "BumpPanelService", ServiceFake)
+    bot = BotFake()
+    return bump_cog.BumpPanelCog(bot), bot
+
+
+def test_view_metadata_for_available_and_waiting_states() -> None:
+    async def scenario() -> None:
+        service = ServiceFake()
+
+        available = bump_cog.BumpPanelView(service, available=True)
+        waiting = bump_cog.BumpPanelView(service, available=False)
+
+        assert available.timeout is None
+        assert waiting.timeout is None
+        available_button = available.children[0]
+        waiting_button = waiting.children[0]
+        assert available_button.custom_id == "bump_panel:open_command"
+        assert available_button.label == "BUMPする"
+        assert available_button.style is discord.ButtonStyle.success
+        assert available_button.disabled is False
+        assert waiting_button.custom_id == "bump_panel:open_command"
+        assert waiting_button.label == "BUMP待機中"
+        assert waiting_button.style is discord.ButtonStyle.secondary
+        assert waiting_button.disabled is True
+
+    asyncio.run(scenario())
+
+
+def test_button_callback_delegates_to_service() -> None:
+    async def scenario() -> None:
+        service = ServiceFake()
+        view = bump_cog.BumpPanelView(service, available=True)
+        interaction = object()
+        await view.children[0].callback(interaction)
+        assert service.calls == [("send_command_guide", interaction)]
+
+    asyncio.run(scenario())
+
+
+def test_cog_lifecycle_and_events_delegate(tmp_path: Path, monkeypatch) -> None:
+    async def scenario() -> None:
+        cog, bot = make_cog(tmp_path, monkeypatch)
+        message = object()
+
+        await cog.cog_load()
+        await cog.on_ready()
+        await cog.on_message(message)
+        await cog.cog_unload()
+
+        assert len(bot.views) == 1
+        assert bot.views[0].timeout is None
+        assert cog.service.calls == [
+            ("initialize",),
+            ("ensure_panel",),
+            ("handle_message", message),
+            ("shutdown",),
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_setup_adds_cog_and_main_registers_extension(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    async def scenario() -> None:
+        monkeypatch.setattr(bump_cog, "get_config", lambda: config(tmp_path))
+        monkeypatch.setattr(bump_cog, "BumpPanelService", ServiceFake)
+        bot = BotFake()
+        await bump_cog.setup(bot)
+        assert len(bot.cogs) == 1
+        assert isinstance(bot.cogs[0], bump_cog.BumpPanelCog)
+
+    asyncio.run(scenario())
+    assert "cogs.bump_panel" in main.COGS

--- a/tests/test_bump_panel_repository.py
+++ b/tests/test_bump_panel_repository.py
@@ -1,0 +1,131 @@
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+import storage.json_store as json_store
+from repositories.bump_panel_repository import BumpPanelRepository
+
+
+def test_missing_file_loads_defaults_without_creating_file(tmp_path: Path) -> None:
+    path = tmp_path / "runtime" / "bump.json"
+    repository = BumpPanelRepository(path)
+
+    repository.load()
+
+    assert repository.get_last_bumped_at() is None
+    assert repository.get_next_bump_at() is None
+    assert repository.get_panel_message_id() == 0
+    assert not path.exists()
+
+
+def test_state_round_trip_uses_aware_iso_datetimes(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "bump.json"
+    last = datetime(2026, 8, 1, 1, 2, tzinfo=timezone.utc)
+    next_time = last + timedelta(seconds=7200)
+    repository = BumpPanelRepository(path)
+    repository.set_bump_times(last_bumped_at=last, next_bump_at=next_time)
+    repository.set_panel_message_id(123)
+    repository.save()
+
+    loaded = BumpPanelRepository(path)
+    loaded.load()
+
+    assert loaded.get_last_bumped_at() == last
+    assert loaded.get_next_bump_at() == next_time
+    assert loaded.get_panel_message_id() == 123
+    assert loaded.get_last_bumped_at().utcoffset() == timedelta(0)
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "last_bumped_at": "2026-08-01T01:02:00+00:00",
+        "next_bump_at": "2026-08-01T03:02:00+00:00",
+        "panel_message_id": 123,
+    }
+
+
+def test_clear_next_bump_at_preserves_other_state(tmp_path: Path) -> None:
+    path = tmp_path / "bump.json"
+    last = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    repository = BumpPanelRepository(path)
+    repository.set_bump_times(
+        last_bumped_at=last,
+        next_bump_at=last + timedelta(hours=2),
+    )
+    repository.set_panel_message_id(55)
+    repository.clear_next_bump_at()
+    repository.save()
+
+    state = json.loads(path.read_text(encoding="utf-8"))
+    assert state == {
+        "last_bumped_at": last.isoformat(),
+        "next_bump_at": None,
+        "panel_message_id": 55,
+    }
+
+
+@pytest.mark.parametrize("field", ["last_bumped_at", "next_bump_at"])
+def test_load_rejects_invalid_datetime_without_overwriting(
+    tmp_path: Path,
+    field: str,
+) -> None:
+    path = tmp_path / "bump.json"
+    state = {
+        "last_bumped_at": None,
+        "next_bump_at": None,
+        "panel_message_id": 0,
+    }
+    state[field] = "not-a-date"
+    original = json.dumps(state)
+    path.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ValueError, match=field):
+        BumpPanelRepository(path).load()
+
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_load_propagates_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "bump.json"
+    path.write_text("{invalid", encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
+        BumpPanelRepository(path).load()
+
+
+def test_naive_datetimes_are_rejected(tmp_path: Path) -> None:
+    repository = BumpPanelRepository(tmp_path / "bump.json")
+    aware = datetime.now(timezone.utc)
+
+    with pytest.raises(ValueError, match="timezone-aware"):
+        repository.set_bump_times(
+            last_bumped_at=datetime.now(),
+            next_bump_at=aware,
+        )
+
+
+def test_atomic_save_failure_preserves_existing_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = tmp_path / "bump.json"
+    original = '{"sentinel": "日本語"}'
+    path.write_text(original, encoding="utf-8")
+    repository = BumpPanelRepository(path)
+    repository.set_panel_message_id(9)
+
+    def fail_replace(_source: object, _target: object) -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(json_store.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="replace failed"):
+        repository.save()
+
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_repository_exposes_values_not_raw_state(tmp_path: Path) -> None:
+    repository = BumpPanelRepository(tmp_path / "bump.json")
+    repository.load()
+
+    assert not hasattr(repository, "get_state")
+    assert not hasattr(repository, "state")

--- a/tests/test_bump_panel_service.py
+++ b/tests/test_bump_panel_service.py
@@ -1,0 +1,415 @@
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import services.bump_panel_service as bump_service
+from repositories.bump_panel_repository import BumpPanelRepository
+from services.bump_panel_service import BumpPanelService, is_bump_success_message
+
+NOW = datetime(2026, 8, 1, 3, 0, tzinfo=timezone.utc)
+
+
+class FakePanelMessage:
+    def __init__(self, message_id: int) -> None:
+        self.id = message_id
+        self.edits: list[dict[str, object]] = []
+        self.deleted = False
+        self.delete_error: Exception | None = None
+
+    async def edit(self, **kwargs: object) -> None:
+        self.edits.append(kwargs)
+
+    async def delete(self) -> None:
+        if self.delete_error:
+            raise self.delete_error
+        self.deleted = True
+
+
+class FakeChannel:
+    def __init__(self, channel_id: int = 10) -> None:
+        self.id = channel_id
+        self.messages: dict[int, FakePanelMessage] = {}
+        self.sent: list[dict[str, object]] = []
+        self.next_id = 100
+        self.fetch_error: Exception | None = None
+
+    async def fetch_message(self, message_id: int) -> FakePanelMessage:
+        if self.fetch_error:
+            raise self.fetch_error
+        return self.messages[message_id]
+
+    async def send(self, **kwargs: object) -> FakePanelMessage:
+        self.sent.append(kwargs)
+        message = FakePanelMessage(self.next_id)
+        self.messages[message.id] = message
+        self.next_id += 1
+        return message
+
+
+class FakeBot:
+    def __init__(self, channel: FakeChannel | None) -> None:
+        self.channel = channel
+
+    def get_channel(self, channel_id: int) -> FakeChannel | None:
+        if self.channel is not None and self.channel.id == channel_id:
+            return self.channel
+        return None
+
+
+def make_service(
+    tmp_path: Path,
+    *,
+    channel: FakeChannel | None = None,
+    command_id: int | None = 30,
+    now: datetime = NOW,
+    sleep_func=asyncio.sleep,
+) -> tuple[BumpPanelService, BumpPanelRepository]:
+    repository = BumpPanelRepository(tmp_path / "runtime" / "bump.json")
+    service = BumpPanelService(
+        bot=FakeBot(channel),
+        repository=repository,
+        channel_id=10,
+        disboard_bot_id=20,
+        bump_command_id=command_id,
+        cooldown_seconds=7200,
+        view_factory=lambda available: f"view:{available}",
+        now_factory=lambda: now,
+        sleep_func=sleep_func,
+    )
+    return service, repository
+
+
+def message(
+    *,
+    channel_id: int = 10,
+    author_id: int = 20,
+    command_name: str | None = "bump",
+    content: str = "",
+    embeds: list[object] | None = None,
+) -> SimpleNamespace:
+    metadata = (
+        SimpleNamespace(name=command_name) if command_name is not None else None
+    )
+    return SimpleNamespace(
+        channel=SimpleNamespace(id=channel_id),
+        author=SimpleNamespace(id=author_id),
+        interaction_metadata=metadata,
+        content=content,
+        embeds=embeds or [],
+    )
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expected"),
+    [
+        (message(), True),
+        (message(channel_id=11), False),
+        (message(author_id=21), False),
+        (message(command_name="help"), False),
+        (message(author_id=99, content="/bump"), False),
+        (message(command_name=None, content="unrelated response"), False),
+        (message(command_name=None, content="Bump done! Thanks"), True),
+        (
+            message(
+                command_name=None,
+                embeds=[SimpleNamespace(
+                    title="BUMP成功",
+                    description="表示順を更新しました",
+                    author=None,
+                    footer=None,
+                )],
+            ),
+            True,
+        ),
+    ],
+)
+def test_bump_success_detection(candidate: object, expected: bool) -> None:
+    assert is_bump_success_message(
+        candidate,
+        channel_id=10,
+        disboard_bot_id=20,
+    ) is expected
+
+
+def test_initial_and_past_state_are_available(tmp_path: Path) -> None:
+    service, repository = make_service(tmp_path)
+    repository.load()
+    assert service.is_available() is True
+    repository.set_bump_times(
+        last_bumped_at=NOW - timedelta(hours=3),
+        next_bump_at=NOW - timedelta(hours=1),
+    )
+    assert service.is_available() is True
+
+
+def test_future_state_is_waiting(tmp_path: Path) -> None:
+    service, repository = make_service(tmp_path)
+    repository.load()
+    repository.set_bump_times(
+        last_bumped_at=NOW,
+        next_bump_at=NOW + timedelta(hours=2),
+    )
+    assert service.is_available() is False
+
+
+def test_initialize_updates_existing_panel_and_sleeps_remaining_time(
+    tmp_path: Path,
+) -> None:
+    sleeps: list[float] = []
+    blocker = asyncio.Event()
+
+    async def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        await blocker.wait()
+
+    async def scenario() -> None:
+        channel = FakeChannel()
+        panel = FakePanelMessage(44)
+        channel.messages[44] = panel
+        service, repository = make_service(
+            tmp_path,
+            channel=channel,
+            sleep_func=sleep,
+        )
+        repository.load()
+        repository.set_bump_times(
+            last_bumped_at=NOW,
+            next_bump_at=NOW + timedelta(minutes=30),
+        )
+        repository.set_panel_message_id(44)
+        repository.save()
+
+        await service.initialize()
+        await asyncio.sleep(0)
+
+        assert sleeps == [1800]
+        assert panel.edits[0]["view"] == "view:False"
+        await service.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_bump_success_saves_times_reposts_panel_and_finishes_cooldown(
+    tmp_path: Path,
+) -> None:
+    sleeps: list[float] = []
+
+    async def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    async def scenario() -> None:
+        channel = FakeChannel()
+        old_panel = FakePanelMessage(44)
+        channel.messages[44] = old_panel
+        service, repository = make_service(
+            tmp_path,
+            channel=channel,
+            sleep_func=sleep,
+        )
+        repository.load()
+        repository.set_panel_message_id(44)
+
+        await service.record_bump_success()
+        assert repository.get_last_bumped_at() == NOW
+        assert repository.get_next_bump_at() == NOW + timedelta(seconds=7200)
+        assert old_panel.deleted is True
+        assert channel.sent[0]["view"] == "view:False"
+        assert repository.get_panel_message_id() == 100
+
+        await asyncio.sleep(0)
+        assert sleeps == [7200]
+        assert repository.get_next_bump_at() is None
+        assert channel.messages[100].edits[-1]["view"] == "view:True"
+        await service.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_new_bump_cancels_existing_task(tmp_path: Path) -> None:
+    cancelled = asyncio.Event()
+
+    async def sleep(_seconds: float) -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    async def scenario() -> None:
+        service, repository = make_service(
+            tmp_path,
+            channel=FakeChannel(),
+            sleep_func=sleep,
+        )
+        repository.load()
+        await service.record_bump_success()
+        first_task = service._cooldown_task
+        await asyncio.sleep(0)
+        await service.record_bump_success()
+        await asyncio.sleep(0)
+        assert first_task is not None and first_task.cancelled()
+        assert cancelled.is_set()
+        assert service._cooldown_task is not first_task
+        await service.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_delete_failure_still_posts_new_panel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class DeleteError(Exception):
+        pass
+
+    monkeypatch.setattr(bump_service.discord, "Forbidden", DeleteError)
+
+    async def scenario() -> None:
+        channel = FakeChannel()
+        old_panel = FakePanelMessage(44)
+        old_panel.delete_error = DeleteError()
+        channel.messages[44] = old_panel
+        service, repository = make_service(tmp_path, channel=channel)
+        repository.load()
+        repository.set_panel_message_id(44)
+        with caplog.at_level(logging.ERROR):
+            await service.record_bump_success()
+        assert len(channel.sent) == 1
+        assert "Failed to delete" in caplog.text
+        await service.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_missing_panel_is_recreated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class NotFoundError(Exception):
+        pass
+
+    monkeypatch.setattr(bump_service.discord, "NotFound", NotFoundError)
+
+    async def scenario() -> None:
+        channel = FakeChannel()
+        channel.fetch_error = NotFoundError()
+        service, repository = make_service(tmp_path, channel=channel)
+        repository.load()
+        repository.set_panel_message_id(44)
+        await service.ensure_panel()
+        assert len(channel.sent) == 1
+        assert repository.get_panel_message_id() == 100
+
+    asyncio.run(scenario())
+
+
+def test_channel_unavailable_is_safe(tmp_path: Path, caplog) -> None:
+    async def scenario() -> None:
+        service, repository = make_service(tmp_path)
+        repository.load()
+        with caplog.at_level(logging.WARNING):
+            await service.ensure_panel()
+        assert "unavailable" in caplog.text
+
+    asyncio.run(scenario())
+
+
+def test_uncertain_disboard_message_does_not_log_content(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def scenario() -> None:
+        service, repository = make_service(tmp_path)
+        repository.load()
+        private_content = "private-message-body"
+        with caplog.at_level(logging.WARNING):
+            await service.handle_message(
+                message(command_name=None, content=private_content)
+            )
+        assert "Unable to confirm" in caplog.text
+        assert private_content not in caplog.text
+        assert repository.get_next_bump_at() is None
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("command_id", "expected"),
+    [
+        (30, "BUMPはこちら：</bump:30>"),
+        (None, "このチャンネルで /bump を入力し、\nDISBOARDのコマンドを選択してください。"),
+    ],
+)
+def test_command_guide_is_ephemeral_and_does_not_change_state(
+    tmp_path: Path,
+    command_id: int | None,
+    expected: str,
+) -> None:
+    class Response:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, bool]] = []
+
+        def is_done(self) -> bool:
+            return False
+
+        async def send_message(self, text: str, *, ephemeral: bool) -> None:
+            self.calls.append((text, ephemeral))
+
+    async def scenario() -> None:
+        service, repository = make_service(tmp_path, command_id=command_id)
+        repository.load()
+        response = Response()
+        interaction = SimpleNamespace(response=response, followup=None)
+        await service.send_command_guide(interaction)
+        assert response.calls == [(expected, True)]
+        assert repository.get_last_bumped_at() is None
+        assert repository.get_next_bump_at() is None
+        assert not (tmp_path / "runtime" / "bump.json").exists()
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_cancels_wait_task(tmp_path: Path) -> None:
+    async def sleep(_seconds: float) -> None:
+        await asyncio.Event().wait()
+
+    async def scenario() -> None:
+        service, repository = make_service(tmp_path, sleep_func=sleep)
+        repository.load()
+        service._schedule_cooldown(NOW + timedelta(hours=2))
+        task = service._cooldown_task
+        await asyncio.sleep(0)
+        await service.shutdown()
+        assert task is not None and task.cancelled()
+
+    asyncio.run(scenario())
+
+
+def test_cooldown_task_logs_unexpected_failure(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    async def scenario() -> None:
+        service, repository = make_service(tmp_path, sleep_func=no_sleep)
+        repository.load()
+
+        def fail_save() -> None:
+            raise OSError("private failure detail")
+
+        repository.save = fail_save  # type: ignore[method-assign]
+        with caplog.at_level(logging.ERROR):
+            service._schedule_cooldown(NOW + timedelta(hours=2))
+            task = service._cooldown_task
+            assert task is not None
+            await task
+        assert "Unexpected failure in the BUMP cooldown task" in caplog.text
+
+    asyncio.run(scenario())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,3 +53,33 @@ def test_config_is_typed_and_cached(monkeypatch) -> None:
     assert config.reaction_role_values["RR_GAME_VALO"] == "10:20"
     assert config.log_level == "INFO"
     assert "private-token" not in repr(config)
+
+
+def test_bump_panel_config_values(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("APPLICATION_ID", "101")
+    monkeypatch.setenv("GUILD_ID", "202")
+    monkeypatch.setenv("BUMP_CHANNEL_ID", "1432640140911575060")
+    monkeypatch.setenv("DISBOARD_BOT_ID", "302050872383242240")
+    monkeypatch.setenv("DISBOARD_BUMP_COMMAND_ID", "947088344167366698")
+    monkeypatch.setenv("BUMP_COOLDOWN_SECONDS", "3600")
+    monkeypatch.setenv("RUNTIME_DATA_DIR", str(tmp_path))
+
+    config = get_config()
+
+    assert config.bump_channel_id == 1432640140911575060
+    assert config.disboard_bot_id == 302050872383242240
+    assert config.disboard_bump_command_id == 947088344167366698
+    assert config.bump_cooldown_seconds == 3600
+    assert config.bump_panel_state_path == tmp_path / "bump_panel_state.json"
+
+
+def test_bump_panel_optional_command_and_cooldown_fallback(monkeypatch) -> None:
+    monkeypatch.setenv("APPLICATION_ID", "101")
+    monkeypatch.setenv("GUILD_ID", "202")
+    monkeypatch.delenv("DISBOARD_BUMP_COMMAND_ID", raising=False)
+    monkeypatch.setenv("BUMP_COOLDOWN_SECONDS", "0")
+
+    config = get_config()
+
+    assert config.disboard_bump_command_id is None
+    assert config.bump_cooldown_seconds == 7200

--- a/tests/test_repository_architecture.py
+++ b/tests/test_repository_architecture.py
@@ -16,6 +16,7 @@ REPOSITORY_PATHS = tuple(
         "xmas_repository.py",
         "valomap_repository.py",
         "valocheck_repository.py",
+        "bump_panel_repository.py",
     )
 )
 SERVICE_PATHS = tuple(sorted((ROOT / "services").glob("*.py")))

--- a/tests/test_runtime_paths.py
+++ b/tests/test_runtime_paths.py
@@ -13,11 +13,13 @@ RUNTIME_ENV_NAMES = (
     "RUNTIME_DATA_DIR",
     "STATE_DIRECTORY",
     "XDG_DATA_HOME",
+    "HOME",
     "VALO_CHECK_DATA_PATH",
     "OMIKUJI_POINTS_PATH",
     "JOYA_DATA_PATH",
     "XMAS_GACHA_STATE",
     "VALOMAP_BANS_PATH",
+    "BUMP_PANEL_STATE_PATH",
 )
 
 
@@ -25,7 +27,6 @@ RUNTIME_ENV_NAMES = (
 def isolated_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     get_config.cache_clear()
     monkeypatch.setattr(config_module, "load_dotenv", lambda: None)
-    monkeypatch.setattr(config_module.Path, "home", lambda: tmp_path / "home")
     monkeypatch.setenv("APPLICATION_ID", "1")
     monkeypatch.setenv("GUILD_ID", "1")
     for name in RUNTIME_ENV_NAMES:
@@ -50,6 +51,32 @@ def test_runtime_data_dir_precedence(tmp_path: Path) -> None:
     assert resolve_runtime_data_dir(environ, tmp_path / "home") == (
         tmp_path / "home" / ".local" / "share" / "wankoro-bot"
     )
+
+
+def test_runtime_data_dir_falls_back_to_current_data_directory(tmp_path: Path) -> None:
+    data_dir = tmp_path / "checkout" / "data"
+
+    assert resolve_runtime_data_dir({}, None, data_dir) == data_dir
+
+
+def test_config_uses_home_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+
+    assert get_config().valo_check_data_path == (
+        home / ".local" / "share" / "wankoro-bot" / "valo_check_completed.json"
+    )
+
+
+def test_config_uses_data_fallback_without_home(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HOME", raising=False)
+
+    assert get_config().valo_check_data_path == Path("data/valo_check_completed.json")
 
 
 def test_runtime_data_dir_ignores_empty_values_and_strips_whitespace(tmp_path: Path) -> None:
@@ -81,6 +108,7 @@ def test_state_directory_is_used_as_provided(tmp_path: Path) -> None:
         ("JOYA_DATA_PATH", "joya_data_path", "2026_joya_state.json"),
         ("XMAS_GACHA_STATE", "xmas_gacha_state_path", "xmas_gacha_state.json"),
         ("VALOMAP_BANS_PATH", "valomap_bans_path", "valomap_bans.json"),
+        ("BUMP_PANEL_STATE_PATH", "bump_panel_state_path", "bump_panel_state.json"),
     ],
 )
 def test_config_runtime_paths_use_root_when_individual_path_is_missing(
@@ -105,16 +133,20 @@ def test_config_runtime_paths_use_root_when_individual_path_is_missing(
         ("JOYA_DATA_PATH", "joya_data_path"),
         ("XMAS_GACHA_STATE", "xmas_gacha_state_path"),
         ("VALOMAP_BANS_PATH", "valomap_bans_path"),
+        ("BUMP_PANEL_STATE_PATH", "bump_panel_state_path"),
     ],
 )
-@pytest.mark.parametrize("explicit_path", [Path("relative/state.json"), Path("/tmp/state.json")])
+@pytest.mark.parametrize("absolute", [False, True])
 def test_individual_path_overrides_runtime_root_without_changing_path_kind(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     environment_name: str,
     field_name: str,
-    explicit_path: Path,
+    absolute: bool,
 ) -> None:
+    explicit_path = tmp_path / "absolute" / "state.json" if absolute else Path(
+        "relative/state.json"
+    )
     monkeypatch.setenv("RUNTIME_DATA_DIR", str(tmp_path / "runtime"))
     monkeypatch.setenv(environment_name, str(explicit_path))
 
@@ -154,6 +186,7 @@ def test_config_creation_has_no_runtime_filesystem_side_effects(
         ("JOYA_DATA_PATH", "joya_data_path", "2026_joya_state.json"),
         ("XMAS_GACHA_STATE", "xmas_gacha_state_path", "xmas_gacha_state.json"),
         ("VALOMAP_BANS_PATH", "valomap_bans_path", "valomap_bans.json"),
+        ("BUMP_PANEL_STATE_PATH", "bump_panel_state_path", "bump_panel_state.json"),
     ],
 )
 def test_empty_individual_path_uses_runtime_root(


### PR DESCRIPTION
## 概要

DISBOARDの`/bump`を実行しやすくする常設パネルを追加しました。

Closes #49

## 主な変更

- BUMP専用チャンネルへ常設パネルを追加
- BUMP可能時は緑色の有効ボタンを表示
- クールダウン中はグレーの無効ボタンを表示
- DISBOARDのBUMP成功メッセージを検知
- 成功時刻と次回可能時刻を永続化
- 2時間後に単一Taskでパネルを自動有効化
- Bot再起動後にクールダウン状態を復元
- ボタン押下時にDISBOARDのSlash Commandメンションをephemeral表示
- BUMP成功時にパネルを最下部へ再投稿
- runtime stateをRepository経由で保存

## 設計

```text
Cog
↓
Service
↓
Repository
↓
storage/json_store.py
```

## Slash Command

```text
</bump:947088344167366698>
```

BotがDISBOARDコマンドを自動実行する処理はありません。

## Validation

- pytest: 302 passed
- Ruff: All checks passed
- compileall: 成功
- pip check: No broken requirements found
- main import: 成功
- 全Cog import/setup: 11/11成功
- 全Service import: 成功
- 全Repository import: 成功
- Discord接続なし
- Bot起動なし
- runtime JSON変更なし