### PR TITLE
feat: add availability poll admin commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ cogs/availability_poll
 VALORANT・その他ゲーム・作業VCを匿名集計し、回答は変更・取消できます。平日と
 休日の設定window内で時刻を一度だけ抽選し、保存した次回時刻まで単一taskで待機します。
 管理者は`/availability_poll_skip_next`、`/availability_poll_stop`、
-`/availability_poll_resume`を利用できます。
+`/availability_poll_resume`に加え、`/availability_poll_post`、
+`/availability_poll_status`、`/availability_poll_close`を利用できます。手動postは
+停止中でも利用でき、次回定期投稿時刻やskip状態を変更しません。statusは状態を変更せず、
+closeは現在のpollだけを締め切り、次回定期投稿は予定どおり維持します。
 
 公開表示には回答者情報を出しませんが、回答変更のためruntime stateにはDiscord User
 IDを保存し、回答操作と状態が変わった管理Command操作は管理専用Discordサーバーへ

--- a/cogs/availability_poll.py
+++ b/cogs/availability_poll.py
@@ -173,6 +173,42 @@ class AvailabilityPollCog(commands.Cog):
     ) -> None:
         await self.service.resume(interaction)
 
+    @app_commands.command(
+        name="availability_poll_post",
+        description="「いまひま？」アンケートを今すぐ投稿します",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def availability_poll_post(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        await self.service.post_now(interaction)
+
+    @app_commands.command(
+        name="availability_poll_status",
+        description="「いまひま？」アンケートの現在状態を確認します",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def availability_poll_status(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        await self.service.status(interaction)
+
+    @app_commands.command(
+        name="availability_poll_close",
+        description="現在の「いまひま？」アンケートを締め切ります",
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def availability_poll_close(
+        self,
+        interaction: discord.Interaction,
+    ) -> None:
+        await self.service.close_current(interaction)
+
     async def _command_error(
         self,
         interaction: discord.Interaction,
@@ -204,6 +240,30 @@ class AvailabilityPollCog(commands.Cog):
 
     @availability_poll_resume.error
     async def resume_error(
+        self,
+        interaction: discord.Interaction,
+        error: app_commands.AppCommandError,
+    ) -> None:
+        await self._command_error(interaction, error)
+
+    @availability_poll_post.error
+    async def post_error(
+        self,
+        interaction: discord.Interaction,
+        error: app_commands.AppCommandError,
+    ) -> None:
+        await self._command_error(interaction, error)
+
+    @availability_poll_status.error
+    async def status_error(
+        self,
+        interaction: discord.Interaction,
+        error: app_commands.AppCommandError,
+    ) -> None:
+        await self._command_error(interaction, error)
+
+    @availability_poll_close.error
+    async def close_error(
         self,
         interaction: discord.Interaction,
         error: app_commands.AppCommandError,

--- a/repositories/availability_poll_repository.py
+++ b/repositories/availability_poll_repository.py
@@ -149,6 +149,25 @@ class AvailabilityPollRepository:
             }
         )
 
+    def restore_active_poll(self, active: ActivePoll | None) -> None:
+        """Restore an immutable snapshot after a failed persistence attempt."""
+
+        if active is None:
+            self._state["active_poll"] = None
+            return
+        self._state["active_poll"] = self._validate_active_poll(
+            {
+                "poll_id": active.poll_id,
+                "message_id": active.message_id,
+                "channel_id": active.channel_id,
+                "opened_at": active.opened_at.isoformat(),
+                "closed_at": (
+                    active.closed_at.isoformat() if active.closed_at is not None else None
+                ),
+                "answers": dict(active.answers),
+            }
+        )
+
     def close_active_poll(self, closed_at: datetime) -> None:
         _require_aware(closed_at, "closed_at")
         active = self._state["active_poll"]

--- a/services/availability_poll_service.py
+++ b/services/availability_poll_service.py
@@ -255,13 +255,18 @@ class AvailabilityPollService:
         prefix = "Poll ID: "
         return text[len(prefix) :] if isinstance(text, str) and text.startswith(prefix) else None
 
-    async def _publish_poll(self, scheduled_at: datetime) -> bool:
+    async def _publish_poll(
+        self,
+        scheduled_at: datetime,
+        *,
+        poll_id: str | None = None,
+    ) -> bool:
         channel = self.bot.get_channel(self._channel_id)
         if channel is None:
             logger.warning("Availability poll channel is unavailable")
             return False
         await self._close_active_poll()
-        poll_id = scheduled_at.astimezone(self._timezone).isoformat()
+        poll_id = poll_id or scheduled_at.astimezone(self._timezone).isoformat()
         try:
             message = await channel.send(
                 embed=self.public_embed(poll_id, {answer: 0 for answer in ANSWERS}),
@@ -270,13 +275,19 @@ class AvailabilityPollService:
         except (discord.Forbidden, discord.HTTPException):
             logger.exception("Failed to post an availability poll")
             return False
-        self._repository.create_poll(
-            poll_id=poll_id,
-            message_id=message.id,
-            channel_id=self._channel_id,
-            opened_at=self._now(),
-        )
-        self._repository.save()
+        previous = self._repository.get_active_poll()
+        try:
+            self._repository.create_poll(
+                poll_id=poll_id,
+                message_id=message.id,
+                channel_id=self._channel_id,
+                opened_at=self._now(),
+            )
+            self._repository.save()
+        except Exception:
+            self._repository.restore_active_poll(previous)
+            logger.exception("Failed to save a posted availability poll")
+            return False
         logger.info("Availability poll posted")
         return True
 
@@ -474,6 +485,119 @@ class AvailabilityPollService:
             logger.info("Availability poll scheduler resumed")
             await self._send_admin_audit(interaction, "定期投稿を再開")
 
+    async def post_now(self, interaction: discord.Interaction) -> None:
+        """Post a poll without changing any regular scheduler controls."""
+
+        async with self._lock:
+            now = self._now()
+            poll_id = f"manual:{now.astimezone(self._timezone).isoformat()}"
+            try:
+                posted = await self._publish_poll(now, poll_id=poll_id)
+            except Exception:
+                logger.exception("Failed to manually post an availability poll")
+                posted = False
+            if not posted:
+                await self._respond(
+                    interaction,
+                    "アンケートを投稿できなかったよ。\nログを確認してください。",
+                )
+                return
+            await self._respond(
+                interaction,
+                "「いまひま？」アンケートを投稿したよ🐶\n"
+                "次の定期投稿予定はそのままだよ。",
+            )
+            await self._send_admin_audit(
+                interaction,
+                "アンケートを手動投稿",
+                poll_id=poll_id,
+            )
+
+    async def status(self, interaction: discord.Interaction) -> None:
+        """Report repository state without saving or touching the scheduler."""
+
+        async with self._lock:
+            paused = self._repository.is_paused()
+            skip = self._repository.should_skip_next_run()
+            next_run = self._repository.get_next_run_at()
+            active = self._repository.get_active_poll()
+            counts = self._repository.get_counts()
+
+            if paused and next_run is None:
+                next_run_text = "停止中"
+            elif next_run is None:
+                next_run_text = "未定"
+            else:
+                next_run_text = self._format_local_datetime(next_run)
+            lines = [
+                "🐶 「いまひま？」現在状態",
+                "",
+                f"定期投稿：{'無期限停止中' if paused else '稼働中'}",
+                f"次回のみスキップ：{'あり' if skip else 'なし'}",
+                f"次回定期投稿：{next_run_text}",
+                "",
+            ]
+            if active is None:
+                lines.append("現在のアンケート：なし")
+            else:
+                lines.extend(
+                    [
+                        "現在のアンケート："
+                        f"{'締切済み' if active.closed_at is not None else '受付中'}",
+                        f"Poll ID：{active.poll_id}",
+                        f"投稿日時：{self._format_local_datetime(active.opened_at)}",
+                        f"Message ID：{active.message_id}",
+                        "",
+                        "現在の結果：",
+                        "\n".join(
+                            f"{ICONS[answer]} {LABELS[answer]} {counts[answer]}人"
+                            for answer in ANSWERS
+                        ),
+                    ]
+                )
+            await self._respond(interaction, "\n".join(lines))
+
+    async def close_current(self, interaction: discord.Interaction) -> None:
+        """Close only the current poll while preserving regular scheduling."""
+
+        async with self._lock:
+            active = self._repository.get_active_poll()
+            if active is None:
+                await self._respond(
+                    interaction,
+                    "現在、締め切れるアンケートはないよ。",
+                )
+                return
+            if active.closed_at is not None:
+                await self._respond(
+                    interaction,
+                    "現在のアンケートは、すでに締め切られているよ。",
+                )
+                return
+            try:
+                await self._close_active_poll()
+            except Exception:
+                self._repository.restore_active_poll(active)
+                logger.exception("Failed to save the closed availability poll")
+                await self._respond(
+                    interaction,
+                    "アンケートを締め切れなかったよ。\nログを確認してください。",
+                )
+                return
+            await self._respond(
+                interaction,
+                "現在のアンケートを締め切ったよ🐶\n"
+                "次の定期投稿予定はそのままだよ。",
+            )
+            await self._send_admin_audit(
+                interaction,
+                "現在のアンケートを締切",
+                poll_id=active.poll_id,
+            )
+
+    def _format_local_datetime(self, value: datetime) -> str:
+        return value.astimezone(self._timezone).strftime("%Y/%m/%d %H:%M:%S %Z")
+
     async def _cancel_scheduler(self) -> None:
         task = self._scheduler_task
         self._scheduler_task = None
@@ -534,13 +658,16 @@ class AvailabilityPollService:
         self,
         interaction: discord.Interaction,
         operation: str,
+        *,
+        poll_id: str | None = None,
     ) -> None:
         user = interaction.user
+        poll_line = f"\nPoll ID：{poll_id}" if poll_id is not None else ""
         embed = discord.Embed(
             title="⚙️ 「いまひま？」運用ログ",
             description=(
                 f"操作：{operation}\n実行者：{user.mention}\n"
-                f"表示名：{user.display_name}\nUser ID：{user.id}\n"
+                f"表示名：{user.display_name}\nUser ID：{user.id}{poll_line}\n"
                 f"操作日時：{self._now().astimezone(self._timezone):%Y-%m-%d %H:%M:%S %Z}"
             ),
         )

--- a/tests/test_availability_poll_admin_commands.py
+++ b/tests/test_availability_poll_admin_commands.py
@@ -1,0 +1,212 @@
+import asyncio
+from datetime import timedelta
+
+from tests.test_availability_poll_service import (
+    NOW,
+    Channel,
+    Message,
+    interaction,
+    make_service,
+    prepare_poll,
+)
+
+
+def test_manual_post_preserves_schedule_controls_and_audits(tmp_path) -> None:
+    async def scenario() -> None:
+        public = Channel(10)
+        audit = Channel(40)
+        service, repository = make_service(tmp_path, public=public, audit=audit)
+        repository.load()
+        next_run = NOW + timedelta(hours=2)
+        repository.set_next_run_at(next_run)
+        repository.set_paused(True)
+        repository.set_skip_next_run(True)
+        repository.save()
+        scheduler = object()
+        service._scheduler_task = scheduler
+
+        command = interaction(Message(999))
+        await service.post_now(command)
+
+        active = repository.get_active_poll()
+        assert active is not None
+        assert active.poll_id.startswith("manual:")
+        assert active.answers == {}
+        assert repository.get_next_run_at() == next_run
+        assert repository.is_paused() is True
+        assert repository.should_skip_next_run() is True
+        assert service._scheduler_task is scheduler
+        assert command.response.sent[0][1]["ephemeral"] is True
+        assert "投稿したよ" in command.response.sent[0][0][0]
+        assert len(audit.sent) == 1
+        assert "アンケートを手動投稿" in audit.sent[0]["embed"].description
+        assert active.poll_id in audit.sent[0]["embed"].description
+
+    asyncio.run(scenario())
+
+
+def test_manual_post_closes_previous_poll_and_disables_buttons(tmp_path) -> None:
+    async def scenario() -> None:
+        public = Channel(10)
+        audit = Channel(40)
+        previous_message = Message(100)
+        public.messages[100] = previous_message
+        public.next_id = 101
+        service, repository = make_service(tmp_path, public=public, audit=audit)
+        prepare_poll(repository)
+
+        await service.post_now(interaction(Message(999)))
+
+        assert previous_message.edits[0]["view"] == ("poll", True)
+        active = repository.get_active_poll()
+        assert active is not None and active.message_id == 101
+        assert repository.get_counts() == {
+            "valorant": 0,
+            "other_game": 0,
+            "work_vc": 0,
+        }
+
+    asyncio.run(scenario())
+
+
+def test_manual_post_save_failure_sends_no_audit(tmp_path, monkeypatch) -> None:
+    async def scenario() -> None:
+        public = Channel(10)
+        audit = Channel(40)
+        service, repository = make_service(tmp_path, public=public, audit=audit)
+        repository.load()
+
+        def fail_save() -> None:
+            raise OSError("private persistence detail")
+
+        monkeypatch.setattr(repository, "save", fail_save)
+        command = interaction(Message(999))
+        await service.post_now(command)
+        assert "投稿できなかった" in command.response.sent[0][0][0]
+        assert repository.get_active_poll() is None
+        assert not audit.sent
+
+    asyncio.run(scenario())
+
+
+def test_status_is_read_only_and_reports_active_state(tmp_path, monkeypatch) -> None:
+    async def scenario() -> None:
+        service, repository = make_service(tmp_path)
+        prepare_poll(repository)
+        repository.set_answer(7, "valorant")
+        repository.set_next_run_at(NOW + timedelta(hours=2))
+        repository.set_skip_next_run(True)
+        save_calls = 0
+
+        def forbidden_save() -> None:
+            nonlocal save_calls
+            save_calls += 1
+
+        monkeypatch.setattr(repository, "save", forbidden_save)
+        scheduler = object()
+        service._scheduler_task = scheduler
+        command = interaction(Message(999))
+
+        await service.status(command)
+
+        text = command.response.sent[0][0][0]
+        assert "定期投稿：稼働中" in text
+        assert "次回のみスキップ：あり" in text
+        assert "現在のアンケート：受付中" in text
+        assert "Poll ID：poll" in text
+        assert "Message ID：100" in text
+        assert "🎯 VALORANT 1人" in text
+        assert "🎮 その他ゲーム 0人" in text
+        assert "🗣️ 作業VC 0人" in text
+        assert save_calls == 0
+        assert service._scheduler_task is scheduler
+
+    asyncio.run(scenario())
+
+
+def test_status_reports_paused_without_active_poll(tmp_path) -> None:
+    async def scenario() -> None:
+        service, repository = make_service(tmp_path)
+        repository.load()
+        repository.set_paused(True)
+        command = interaction(Message(999))
+        await service.status(command)
+        text = command.response.sent[0][0][0]
+        assert "定期投稿：無期限停止中" in text
+        assert "次回定期投稿：停止中" in text
+        assert "現在のアンケート：なし" in text
+
+    asyncio.run(scenario())
+
+
+def test_close_current_preserves_schedule_and_audits_once(tmp_path) -> None:
+    async def scenario() -> None:
+        public = Channel(10)
+        audit = Channel(40)
+        message = Message(100)
+        public.messages[100] = message
+        service, repository = make_service(tmp_path, public=public, audit=audit)
+        prepare_poll(repository)
+        repository.set_answer(7, "work_vc")
+        next_run = NOW + timedelta(hours=2)
+        repository.set_next_run_at(next_run)
+        repository.set_skip_next_run(True)
+        scheduler = object()
+        service._scheduler_task = scheduler
+
+        first = interaction(Message(999))
+        await service.close_current(first)
+        active = repository.get_active_poll()
+        assert active is not None and active.closed_at == NOW
+        assert message.edits[0]["view"] == ("poll", True)
+        assert "🐾（1）" in message.edits[0]["embed"].description
+        assert repository.get_next_run_at() == next_run
+        assert repository.should_skip_next_run() is True
+        assert repository.is_paused() is False
+        assert service._scheduler_task is scheduler
+        assert len(audit.sent) == 1
+
+        second = interaction(Message(999))
+        await service.close_current(second)
+        assert "すでに締め切られている" in second.response.sent[0][0][0]
+        assert len(audit.sent) == 1
+
+    asyncio.run(scenario())
+
+
+def test_close_current_without_poll_is_safe(tmp_path) -> None:
+    async def scenario() -> None:
+        audit = Channel(40)
+        service, repository = make_service(tmp_path, audit=audit)
+        repository.load()
+        command = interaction(Message(999))
+        await service.close_current(command)
+        assert "締め切れるアンケートはない" in command.response.sent[0][0][0]
+        assert not audit.sent
+
+    asyncio.run(scenario())
+
+
+def test_close_save_failure_restores_open_state_and_sends_no_audit(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    async def scenario() -> None:
+        public = Channel(10)
+        public.messages[100] = Message(100)
+        audit = Channel(40)
+        service, repository = make_service(tmp_path, public=public, audit=audit)
+        prepare_poll(repository)
+
+        def fail_save() -> None:
+            raise OSError("private persistence detail")
+
+        monkeypatch.setattr(repository, "save", fail_save)
+        command = interaction(Message(999))
+        await service.close_current(command)
+        active = repository.get_active_poll()
+        assert active is not None and active.closed_at is None
+        assert "締め切れなかった" in command.response.sent[0][0][0]
+        assert not audit.sent
+
+    asyncio.run(scenario())

--- a/tests/test_availability_poll_boundaries.py
+++ b/tests/test_availability_poll_boundaries.py
@@ -34,6 +34,15 @@ class ServiceFake:
     async def resume(self, interaction):
         self.calls.append(("resume", interaction))
 
+    async def post_now(self, interaction):
+        self.calls.append(("post", interaction))
+
+    async def status(self, interaction):
+        self.calls.append(("status", interaction))
+
+    async def close_current(self, interaction):
+        self.calls.append(("close", interaction))
+
 
 class BotFake:
     def __init__(self) -> None:
@@ -120,6 +129,9 @@ def test_cog_lifecycle_commands_and_registration(tmp_path, monkeypatch) -> None:
         await cog.availability_poll_skip_next.callback(cog, interaction)
         await cog.availability_poll_stop.callback(cog, interaction)
         await cog.availability_poll_resume.callback(cog, interaction)
+        await cog.availability_poll_post.callback(cog, interaction)
+        await cog.availability_poll_status.callback(cog, interaction)
+        await cog.availability_poll_close.callback(cog, interaction)
         await cog.cog_unload()
         assert len(bot.views) == 1
         assert cog.service.calls == [
@@ -127,6 +139,9 @@ def test_cog_lifecycle_commands_and_registration(tmp_path, monkeypatch) -> None:
             ("skip", interaction),
             ("stop", interaction),
             ("resume", interaction),
+            ("post", interaction),
+            ("status", interaction),
+            ("close", interaction),
             ("shutdown",),
         ]
 
@@ -140,13 +155,50 @@ def test_slash_command_metadata_and_permissions(tmp_path, monkeypatch) -> None:
         cog.availability_poll_skip_next.name: cog.availability_poll_skip_next,
         cog.availability_poll_stop.name: cog.availability_poll_stop,
         cog.availability_poll_resume.name: cog.availability_poll_resume,
+        cog.availability_poll_post.name: cog.availability_poll_post,
+        cog.availability_poll_status.name: cog.availability_poll_status,
+        cog.availability_poll_close.name: cog.availability_poll_close,
     }
     assert set(commands) == {
         "availability_poll_skip_next",
         "availability_poll_stop",
         "availability_poll_resume",
+        "availability_poll_post",
+        "availability_poll_status",
+        "availability_poll_close",
     }
     assert all(command.default_permissions.administrator for command in commands.values())
+    assert all(command.checks for command in commands.values())
+    assert commands["availability_poll_post"].description == (
+        "「いまひま？」アンケートを今すぐ投稿します"
+    )
+    assert commands["availability_poll_status"].description == (
+        "「いまひま？」アンケートの現在状態を確認します"
+    )
+    assert commands["availability_poll_close"].description == (
+        "現在の「いまひま？」アンケートを締め切ります"
+    )
+
+
+def test_permission_error_is_ephemeral(tmp_path, monkeypatch) -> None:
+    class Response:
+        def __init__(self) -> None:
+            self.sent = []
+
+        async def send_message(self, message, *, ephemeral):
+            self.sent.append((message, ephemeral))
+
+    async def scenario():
+        cog, _bot = make_cog(tmp_path, monkeypatch)
+        response = Response()
+        interaction = SimpleNamespace(response=response)
+        await cog._command_error(
+            interaction,
+            discord.app_commands.MissingPermissions(["administrator"]),
+        )
+        assert response.sent == [("この操作は管理者だけが実行できます。", True)]
+
+    asyncio.run(scenario())
 
 
 def test_setup_is_callable() -> None:


### PR DESCRIPTION
## 概要

匿名「いまひま？」アンケートへ管理者用Commandを追加しました。

Closes #51 

## 追加Command

- `/availability_poll_post`
- `/availability_poll_status`
- `/availability_poll_close`

## 機能

### `/availability_poll_post`

- 今すぐアンケートを投稿
- 既存Pollは締切
- ボタンを無効化
- 集計は維持
- schedulerは変更しない
- next_run_atを変更しない
- pause中・skip中でも実行可能

### `/availability_poll_status`

現在状態を表示

- 稼働状態
- 次回投稿
- skip状態
- Poll ID
- 投稿日時
- Message ID
- 現在集計

状態変更なし

### `/availability_poll_close`

現在のPollのみ締切

- ボタン無効化
- 集計維持
- next_run_at維持
- scheduler維持
- pause維持
- skip維持

## Validation

- pytest: 371 passed
- Ruff: All checks passed
- compileall: OK
- pip check: OK
- import main: OK

## Architecture

- Cog → Service → Repository → storage
- RepositoryはDiscord非依存
- CogからRepository直接操作なし
- schedulerとの競合制御維持
- runtime JSON schema変更なし