### PR TITLE
refactor: organize environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,73 +1,55 @@
-# ==========================================
-# ✅ Discord Bot
-# ==========================================
+##################################################
+# Discord
+##################################################
+# Bot token and Discord application identifiers
 DISCORD_TOKEN=
-
 APPLICATION_ID=
-
 GUILD_ID=
-ADMIN_ID=
 LOG_LEVEL=INFO
 
-# 管理権限ロール (カンマ区切り)
+##################################################
+# Management
+##################################################
+# Emergency Welcome fallback user
+ADMIN_ID=
+# Roles allowed to use /welcome and /ok (comma-separated)
 MANAGER_ROLE_IDS=
 
-# 既存ロール設定（他機能との互換用）
-ROLE_A=
-ROLE_B=
-ROLE_C=
+##################################################
+# Welcome
+##################################################
+# Role eligible for Welcome assignment
+WELCOME_HANDLER_ROLE_ID=
+# Voice channel excluded from active-voice priority
+WELCOME_INACTIVE_VOICE_CHANNEL_ID=
+# Users excluded from normal assignment (comma-separated)
+WELCOME_HANDLER_EXCLUDED_USER_IDS=
 
-# Welcome案内担当に必要なロール
-WELCOME_HANDLER_ROLE_ID=1451758143636901960
-# 設定時、このVCの参加者はVC優先候補から除外
-WELCOME_INACTIVE_VOICE_CHANNEL_ID=940190873101172746
-# Welcome案内担当から常に除外するUser ID（カンマ区切り）
-WELCOME_HANDLER_EXCLUDED_USER_IDS=780783001218842655
-
-# 退出ログチャンネル
+##################################################
+# Leave Log
+##################################################
+# Channel receiving member leave notifications
 LEAVE_LOG_CHANNEL_ID=
 
-# DM転送先ユーザー
+##################################################
+# DM Forward
+##################################################
+# User receiving forwarded DMs
 DM_FORWARD_USER_ID=
 
-# ==========================================
-# ✅ DISBOARD BUMP案内パネル
-# ==========================================
-BUMP_CHANNEL_ID=1432640140911575060
-DISBOARD_BOT_ID=302050872383242240
-# Slash Commandメンション用。未設定時は /bump の手動選択を案内します
-DISBOARD_BUMP_COMMAND_ID=947088344167366698
-BUMP_COOLDOWN_SECONDS=7200
-# 設定時はruntime rootより優先するBUMPパネルstate保存先
-BUMP_PANEL_STATE_PATH=
-
-# ==========================================
-# ✅ 匿名「いまひま？」定期アンケート（Issue #51）
-# ==========================================
-AVAILABILITY_POLL_CHANNEL_ID=
-AVAILABILITY_POLL_TIMEZONE=Asia/Tokyo
-AVAILABILITY_POLL_WEEKDAY_WINDOWS=20:00-21:00
-AVAILABILITY_POLL_HOLIDAY_WINDOWS=13:00-14:00,20:00-21:00
-# 設定時はruntime rootより優先
-AVAILABILITY_POLL_STATE_PATH=
-# 回答者情報を送る管理専用Guild・Channel
-AVAILABILITY_POLL_AUDIT_GUILD_ID=1432757050051399833
-AVAILABILITY_POLL_AUDIT_CHANNEL_ID=1532983253504364737
-
-# ==========================================
-# ✅ Reaction Role（ゲームカテゴリー）
-# ==========================================
+##################################################
+# Reaction Roles
+##################################################
+# Reaction Role panel message IDs (comma-separated)
 REACTION_ROLE_MESSAGE_IDS=
+# Game roles (message ID:role ID)
 RR_GAME_VALO=
 RR_GAME_EFT=
 RR_GAME_SF6=
 RR_GAME_MONSTER_HUNTER=
 RR_GAME_OW2=
 RR_GAME_APEX=
-
-# ==========================================
-# ✅ Reaction Role（VALORANT ランク）
-# ==========================================
+# VALORANT rank roles (message ID:role ID)
 RR_V_IRON=
 RR_V_BRONZE=
 RR_V_SILVER=
@@ -78,47 +60,88 @@ RR_V_ASCENDANT=
 RR_V_IMMORTAL=
 RR_V_RADIANT=
 
-# ==========================================
-# ✅ VALORANT診断・募集
-# ==========================================
+##################################################
+# VALORANT Check
+##################################################
+# Result roles and diagnostic log channel
 ROLE_ENJOY_ID=
 ROLE_GACHI_ID=
 VALO_ROLE_LOG_CHANNEL_ID=
-VALO_CHECK_VIEW_TIMEOUT_SEC=1800
-VALO_CHECK_DATA_PATH=data/valo_check_completed.json
-VALO_CHECK_QUESTIONS_PATH=data/valo_questions.json
+# Static diagnostic data
 VALO_CHECK_INTRO_PATH=data/valo_intro.json
+VALO_CHECK_QUESTIONS_PATH=data/valo_questions.json
+# Diagnostic thresholds, labels, and view timeout
 VALO_CHECK_THRESH_ENJOY_ONLY=6
 VALO_CHECK_THRESH_GACHI_ONLY=12
 VALO_CHECK_LABEL_ENJOY=ENJOYのみ
 VALO_CHECK_LABEL_GACHI=GACHIのみ
 VALO_CHECK_LABEL_BOTH=GACHI+ENJOY
+VALO_CHECK_VIEW_TIMEOUT_SEC=1800
 
+##################################################
+# VALORANT Recruit
+##################################################
+# Recruitment channel, target roles, and cooldown
 VALO_RECRUIT_CHANNEL_ID=
 VALO_ROLE_GACHI_ID=
 VALO_ROLE_ENJOY_ID=
 VALO_RECRUIT_COOLDOWN_SECONDS=300
 
-# ==========================================
-# ✅ イベントとruntime JSON
-# ==========================================
-# 個別Path未設定時の全runtime JSON保存先（STATE_DIRECTORY、XDG、homeより優先）
-RUNTIME_DATA_DIR=
-# VALORANT map BAN保存先（設定時はRUNTIME_DATA_DIRより優先）
-VALOMAP_BANS_PATH=
+##################################################
+# BUMP
+##################################################
+# Panel channel and DISBOARD identifiers
+BUMP_CHANNEL_ID=
+DISBOARD_BOT_ID=302050872383242240
+DISBOARD_BUMP_COMMAND_ID=947088344167366698
+BUMP_COOLDOWN_SECONDS=7200
 
-XMAS_GACHA_CSV=/home/akitig/Desktop/Bot/Toureikai/Wankorobot/data/2025_xmas_gacha.csv
-XMAS_GACHA_STATE=/home/akitig/Desktop/Bot/Toureikai/Wankorobot/data/xmas_gacha_state.json
+##################################################
+# Availability Poll
+##################################################
+# Public poll channel and schedule
+AVAILABILITY_POLL_CHANNEL_ID=
+AVAILABILITY_POLL_TIMEZONE=Asia/Tokyo
+AVAILABILITY_POLL_WEEKDAY_WINDOWS=20:00-21:00
+AVAILABILITY_POLL_HOLIDAY_WINDOWS=13:00-14:00,20:00-21:00
+# Private audit destination
+AVAILABILITY_POLL_AUDIT_GUILD_ID=
+AVAILABILITY_POLL_AUDIT_CHANNEL_ID=
+
+##################################################
+# Xmas Gacha
+##################################################
+# Channel, cutoff, and static prize table
 XMAS_GACHA_CHANNEL_ID=
 XMAS_GACHA_CUTOFF=2025-12-26T07:00:00+09:00
+XMAS_GACHA_CSV=
 
-JOYA_DATA_PATH=./data/joya_state.json
+##################################################
+# Joya
+##################################################
+# Channel, winner role, and random interval seconds
+JOYA_CHANNEL_ID=
+JOYA_WINNER_ROLE_ID=
 JOYA_MIN_SEC=60
 JOYA_MAX_SEC=300
-JOYA_WINNER_ROLE_ID=
-JOYA_CHANNEL_ID=
 
-OMIKUJI_POINTS_PATH=data/2026_omikujii_points.json
+##################################################
+# Omikuji
+##################################################
+# Panel channel, rest voice channel, and reset operator
+OMIKUJI_PANEL_CHANNEL_ID=
 OMIKUJI_REST_VC_ID=
 OMIKUJI_RESETTER_USER_ID=
-OMIKUJI_PANEL_CHANNEL_ID=
+
+##################################################
+# Runtime (Optional Override)
+##################################################
+# Shared mutable-state root; feature paths below take priority when set
+RUNTIME_DATA_DIR=
+JOYA_DATA_PATH=
+OMIKUJI_POINTS_PATH=
+VALO_CHECK_DATA_PATH=
+XMAS_GACHA_STATE=
+VALOMAP_BANS_PATH=
+BUMP_PANEL_STATE_PATH=
+AVAILABILITY_POLL_STATE_PATH=

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ python3 -m venv .venv
 `EnvironmentFile`で読み込めるよう、環境変数名にはASCII英大文字・数字・
 アンダースコアのみを使用します。全設定、型、デフォルト値、runtime pathは
 [`docs/architecture/configuration.md`](docs/architecture/configuration.md)を
-参照してください。
+参照してください。テンプレートは機能単位で並び、ManagementはCommand権限と
+緊急fallback、Welcomeは担当者選出を設定します。旧`ROLE_A/B/C`は廃止済みです。
+Reaction Roleの`RR_V_*`は維持し、任意のruntime path overrideは末尾へまとめています。
 
 ```env
 DISCORD_TOKEN=xxxxxxxxxxxxxxxx
@@ -150,11 +152,6 @@ GUILD_ID=xxxxxxxxxxxxxxxx
 # 管理権限
 ADMIN_ID=xxxxxxxxxxxxxxxx
 MANAGER_ROLE_IDS=1111111111,2222222222
-
-# 既存ロール設定
-ROLE_A=1111111111
-ROLE_B=2222222222
-ROLE_C=3333333333
 
 # ウェルカム案内担当の専用ロール・休止VC・除外User
 WELCOME_HANDLER_ROLE_ID=4444444444

--- a/config.py
+++ b/config.py
@@ -191,9 +191,6 @@ class Config:
 
     admin_id: int | None
     manager_role_ids: frozenset[int]
-    welcome_role_a: int | None
-    welcome_role_b: int | None
-    welcome_role_c: int | None
     welcome_handler_role_id: int | None
     welcome_inactive_voice_channel_id: int | None
     welcome_handler_excluded_user_ids: frozenset[int]
@@ -272,9 +269,6 @@ def _load_config() -> Config:
         log_level=_string_with_default("LOG_LEVEL", "INFO", strip=True),
         admin_id=_optional_int("ADMIN_ID"),
         manager_role_ids=_id_set("MANAGER_ROLE_IDS"),
-        welcome_role_a=_optional_int("ROLE_A"),
-        welcome_role_b=_optional_int("ROLE_B"),
-        welcome_role_c=_optional_int("ROLE_C"),
         welcome_handler_role_id=_strict_optional_id("WELCOME_HANDLER_ROLE_ID"),
         welcome_inactive_voice_channel_id=_strict_optional_id(
             "WELCOME_INACTIVE_VOICE_CHANNEL_ID"

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -12,7 +12,8 @@ Guild ID, and the Discord token. Each Cog then calls `get_config()` at its
 composition boundary and passes only the values required by its Service.
 Service and Repository modules do not import `Config` or call `get_config()`.
 
-Existing environment names and defaults remain unchanged. Application and
+Environment variables are grouped by feature in `.env.example`, which is the
+template for deployment configuration. Application and
 Guild IDs are required when Config is first loaded. Settings required by only
 one Cog remain optional in Config and are validated when that Cog is
 constructed, so a missing Cog-specific setting does not prevent unrelated Cogs
@@ -53,7 +54,9 @@ Repository APIs; a DI container is not needed for the current application.
 | Area | Environment variables |
 |---|---|
 | Discord process | `DISCORD_TOKEN`, `APPLICATION_ID`, `GUILD_ID`, `LOG_LEVEL` |
-| Welcome and moderation | `ADMIN_ID`, `MANAGER_ROLE_IDS`, `ROLE_A`, `ROLE_B`, `ROLE_C`, `WELCOME_HANDLER_ROLE_ID`, `WELCOME_INACTIVE_VOICE_CHANNEL_ID`, `WELCOME_HANDLER_EXCLUDED_USER_IDS`, `LEAVE_LOG_CHANNEL_ID`, `DM_FORWARD_USER_ID` |
+| Management | `ADMIN_ID`, `MANAGER_ROLE_IDS` |
+| Welcome | `WELCOME_HANDLER_ROLE_ID`, `WELCOME_INACTIVE_VOICE_CHANNEL_ID`, `WELCOME_HANDLER_EXCLUDED_USER_IDS` |
+| Leave log and DM forwarding | `LEAVE_LOG_CHANNEL_ID`, `DM_FORWARD_USER_ID` |
 | Reaction Roles | `REACTION_ROLE_MESSAGE_IDS`, every `RR_*` mapping |
 | Runtime storage | `RUNTIME_DATA_DIR`, systemd-provided `STATE_DIRECTORY`, `XDG_DATA_HOME` |
 | VALORANT check | `ROLE_ENJOY_ID`, `ROLE_GACHI_ID`, `VALO_ROLE_LOG_CHANNEL_ID`, `VALO_CHECK_VIEW_TIMEOUT_SEC`, `VALO_CHECK_DATA_PATH`, `VALOMAP_BANS_PATH`, `VALO_CHECK_QUESTIONS_PATH`, `VALO_CHECK_INTRO_PATH`, `VALO_CHECK_THRESH_ENJOY_ONLY`, `VALO_CHECK_THRESH_GACHI_ONLY`, `VALO_CHECK_LABEL_ENJOY`, `VALO_CHECK_LABEL_GACHI`, `VALO_CHECK_LABEL_BOTH` |
@@ -71,6 +74,13 @@ working-directory-relative `data/` directory when no home is available. Empty
 root values are ignored and surrounding whitespace is removed.
 `STATE_DIRECTORY` is the absolute path supplied by systemd and is used directly;
 Config does not rebuild it below `/var/lib`.
+
+`ROLE_A`, `ROLE_B`, and `ROLE_C` are retired. Welcome assignment uses only the
+dedicated Welcome settings above. `RR_V_*` remains part of the Reaction Role
+configuration even though its names are discovered dynamically. Runtime path
+overrides are optional and are grouped at the end of `.env.example`; static
+master-data paths such as the VALORANT intro/questions and Xmas CSV remain with
+their owning features.
 
 Existing feature-specific path whitespace behavior is preserved. Omikuji and
 Xmas paths are stripped; Joya and VALORANT check paths remain literal. An empty

--- a/docs/runtime-data-migration-plan.md
+++ b/docs/runtime-data-migration-plan.md
@@ -102,6 +102,7 @@ Configは、既存の個別path設定を壊さず、次の優先順位でruntime
 2. systemdが `StateDirectory=` から提供する `STATE_DIRECTORY`
 3. `XDG_DATA_HOME/wankoro-bot`
 4. `~/.local/share/wankoro-bot`
+5. homeを解決できない場合は、後方互換としてWorkingDirectory相対の `data/`
 
 個別設定 `VALO_CHECK_DATA_PATH`、`OMIKUJI_POINTS_PATH`、`JOYA_DATA_PATH`、
 `XMAS_GACHA_STATE` が設定されている場合は、後方互換のためroot派生値より優先します。

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,6 +68,20 @@ def test_welcome_handler_optional_config_defaults(monkeypatch) -> None:
     assert config.welcome_handler_excluded_user_ids == frozenset()
 
 
+def test_retired_welcome_role_config_is_absent(monkeypatch) -> None:
+    monkeypatch.setenv("APPLICATION_ID", "101")
+    monkeypatch.setenv("GUILD_ID", "202")
+    monkeypatch.setenv("ROLE_A", "1")
+    monkeypatch.setenv("ROLE_B", "2")
+    monkeypatch.setenv("ROLE_C", "3")
+
+    config = get_config()
+
+    assert not hasattr(config, "welcome_role_a")
+    assert not hasattr(config, "welcome_role_b")
+    assert not hasattr(config, "welcome_role_c")
+
+
 @pytest.mark.parametrize(
     ("name", "value"),
     [

--- a/tests/test_env_example.py
+++ b/tests/test_env_example.py
@@ -1,0 +1,141 @@
+from pathlib import Path
+
+ENV_EXAMPLE = Path(__file__).parents[1] / ".env.example"
+EXPECTED_SECTIONS = [
+    "Discord",
+    "Management",
+    "Welcome",
+    "Leave Log",
+    "DM Forward",
+    "Reaction Roles",
+    "VALORANT Check",
+    "VALORANT Recruit",
+    "BUMP",
+    "Availability Poll",
+    "Xmas Gacha",
+    "Joya",
+    "Omikuji",
+    "Runtime (Optional Override)",
+]
+REQUIRED_KEYS = {
+    "DISCORD_TOKEN",
+    "APPLICATION_ID",
+    "GUILD_ID",
+    "LOG_LEVEL",
+    "ADMIN_ID",
+    "MANAGER_ROLE_IDS",
+    "WELCOME_HANDLER_ROLE_ID",
+    "WELCOME_INACTIVE_VOICE_CHANNEL_ID",
+    "WELCOME_HANDLER_EXCLUDED_USER_IDS",
+    "LEAVE_LOG_CHANNEL_ID",
+    "DM_FORWARD_USER_ID",
+    "REACTION_ROLE_MESSAGE_IDS",
+    "RR_GAME_VALO",
+    "RR_GAME_EFT",
+    "RR_GAME_SF6",
+    "RR_GAME_MONSTER_HUNTER",
+    "RR_GAME_OW2",
+    "RR_GAME_APEX",
+    "RR_V_IRON",
+    "RR_V_BRONZE",
+    "RR_V_SILVER",
+    "RR_V_GOLD",
+    "RR_V_PLATINUM",
+    "RR_V_DIAMOND",
+    "RR_V_ASCENDANT",
+    "RR_V_IMMORTAL",
+    "RR_V_RADIANT",
+    "ROLE_ENJOY_ID",
+    "ROLE_GACHI_ID",
+    "VALO_ROLE_LOG_CHANNEL_ID",
+    "VALO_CHECK_INTRO_PATH",
+    "VALO_CHECK_QUESTIONS_PATH",
+    "VALO_CHECK_THRESH_ENJOY_ONLY",
+    "VALO_CHECK_THRESH_GACHI_ONLY",
+    "VALO_CHECK_LABEL_ENJOY",
+    "VALO_CHECK_LABEL_GACHI",
+    "VALO_CHECK_LABEL_BOTH",
+    "VALO_CHECK_VIEW_TIMEOUT_SEC",
+    "VALO_RECRUIT_CHANNEL_ID",
+    "VALO_ROLE_GACHI_ID",
+    "VALO_ROLE_ENJOY_ID",
+    "VALO_RECRUIT_COOLDOWN_SECONDS",
+    "BUMP_CHANNEL_ID",
+    "DISBOARD_BOT_ID",
+    "DISBOARD_BUMP_COMMAND_ID",
+    "BUMP_COOLDOWN_SECONDS",
+    "AVAILABILITY_POLL_CHANNEL_ID",
+    "AVAILABILITY_POLL_TIMEZONE",
+    "AVAILABILITY_POLL_WEEKDAY_WINDOWS",
+    "AVAILABILITY_POLL_HOLIDAY_WINDOWS",
+    "AVAILABILITY_POLL_AUDIT_GUILD_ID",
+    "AVAILABILITY_POLL_AUDIT_CHANNEL_ID",
+    "XMAS_GACHA_CHANNEL_ID",
+    "XMAS_GACHA_CUTOFF",
+    "XMAS_GACHA_CSV",
+    "JOYA_CHANNEL_ID",
+    "JOYA_WINNER_ROLE_ID",
+    "JOYA_MIN_SEC",
+    "JOYA_MAX_SEC",
+    "OMIKUJI_PANEL_CHANNEL_ID",
+    "OMIKUJI_REST_VC_ID",
+    "OMIKUJI_RESETTER_USER_ID",
+    "RUNTIME_DATA_DIR",
+    "JOYA_DATA_PATH",
+    "OMIKUJI_POINTS_PATH",
+    "VALO_CHECK_DATA_PATH",
+    "XMAS_GACHA_STATE",
+    "VALOMAP_BANS_PATH",
+    "BUMP_PANEL_STATE_PATH",
+    "AVAILABILITY_POLL_STATE_PATH",
+}
+
+
+def _lines() -> list[str]:
+    return ENV_EXAMPLE.read_text(encoding="utf-8").splitlines()
+
+
+def _assignments() -> list[tuple[str, str]]:
+    return [
+        tuple(line.split("=", 1))
+        for line in _lines()
+        if line and not line.startswith("#")
+    ]
+
+
+def test_env_example_has_expected_unique_keys() -> None:
+    assignments = _assignments()
+    keys = [key for key, _value in assignments]
+
+    assert len(keys) == len(set(keys))
+    assert set(keys) == REQUIRED_KEYS
+    assert not {"ROLE_A", "ROLE_B", "ROLE_C"} & set(keys)
+
+
+def test_env_example_sections_are_in_required_order() -> None:
+    lines = _lines()
+    separators = "#" * 50
+    sections = [
+        lines[index + 1].removeprefix("# ")
+        for index, line in enumerate(lines[:-2])
+        if line == separators and lines[index + 2] == separators
+    ]
+
+    assert sections == EXPECTED_SECTIONS
+    assert lines[-1] == "AVAILABILITY_POLL_STATE_PATH="
+
+
+def test_env_example_preserves_rank_roles_and_has_no_token_value() -> None:
+    values = dict(_assignments())
+    assert values["DISCORD_TOKEN"] == ""
+    assert {key for key in values if key.startswith("RR_V_")} == {
+        "RR_V_IRON",
+        "RR_V_BRONZE",
+        "RR_V_SILVER",
+        "RR_V_GOLD",
+        "RR_V_PLATINUM",
+        "RR_V_DIAMOND",
+        "RR_V_ASCENDANT",
+        "RR_V_IMMORTAL",
+        "RR_V_RADIANT",
+    }


### PR DESCRIPTION
## 概要

環境変数設定を機能単位で整理し、`.env.example`を本番`.env`の基準テンプレートとして整備しました。

Closes #55

## 主な変更

- `.env.example`を14セクションへ整理
- ManagementとWelcomeの責務を分離
- 廃止済みの`ROLE_A`、`ROLE_B`、`ROLE_C`を削除
- Configから旧Welcome Role fieldを削除
- `RR_V_*`の9キーを維持
- Runtime Overrideを末尾へ集約
- READMEとConfiguration Architecture文書を更新
- `.env.example`のキー構成・重複・順序をテスト化

## Validation

- pytest: 393 passed
- Ruff: All checks passed
- compileall: 成功
- pip check: No broken requirements found
- main import: 成功
- 全Cog import/setup: 12/12成功
- 全Service import: 成功
- 全Repository import: 成功
- Runtime Path tests: 36 passed
- 本番`.env`変更なし
- runtime JSON変更なし